### PR TITLE
Option to use password_hash instead of encrypted_password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,13 @@ gemfile:
   - gemfiles/Gemfile.rails-4.1-stable
 
 matrix:
+  include:
+    - rvm: 2.6.0
+      gemfile: Gemfile
+      env: DEVISE_ORM=active_record DEVISE_PASSWORD_HASH=t
+    - rvm: 2.5.3
+      gemfile: gemfiles/Gemfile.rails-4.2-stable
+      env: DEVISE_ORM=mongoid DEVISE_PASSWORD_HASH=t
   exclude:
     - rvm: 2.1.10
       gemfile: Gemfile

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -297,6 +297,15 @@ module Devise
   mattr_accessor :sign_in_after_change_password
   @@sign_in_after_change_password = true
 
+  # When true, use password_hash field instead of encrypted_password
+  mattr_accessor :use_password_hash_field
+  @@use_password_hash_field = false
+
+  # Get name of password attribute
+  def self.password_field
+    use_password_hash_field ? :password_hash : :encrypted_password
+  end
+
   def self.rails51? # :nodoc:
     Rails.gem_version >= Gem::Version.new("5.1.x")
   end

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -58,7 +58,7 @@ module Devise
       BLACKLIST_FOR_SERIALIZATION = [:encrypted_password, :reset_password_token, :reset_password_sent_at,
         :remember_created_at, :sign_in_count, :current_sign_in_at, :last_sign_in_at, :current_sign_in_ip,
         :last_sign_in_ip, :password_salt, :confirmation_token, :confirmed_at, :confirmation_sent_at,
-        :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at]
+        :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at, :password_hash]
 
       included do
         class_attribute :devise_modules, instance_writer: false

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -38,7 +38,7 @@ module Devise
       def initialize(*args, &block)
         @skip_email_changed_notification = false
         @skip_password_change_notification = false
-        super 
+        super
       end
 
       # Skips sending the email changed notification after_update
@@ -52,7 +52,7 @@ module Devise
       end
 
       def self.required_fields(klass)
-        [:encrypted_password] + klass.authentication_keys
+        [Devise.password_field] + klass.authentication_keys
       end
 
       # Generates a hashed password based on the given value.
@@ -60,12 +60,12 @@ module Devise
       # the hashed password.
       def password=(new_password)
         @password = new_password
-        self.encrypted_password = password_digest(@password) if @password.present?
+        send("#{Devise.password_field}=", password_digest(@password)) if @password.present?
       end
 
       # Verifies whether a password (ie from sign in) is the user password.
       def valid_password?(password)
-        Devise::Encryptor.compare(self.class, encrypted_password, password)
+        Devise::Encryptor.compare(self.class, send(Devise.password_field), password)
       end
 
       # Set password and password confirmation to nil
@@ -170,7 +170,7 @@ module Devise
 
       # A reliable way to expose the salt regardless of the implementation.
       def authenticatable_salt
-        encrypted_password[0,29] if encrypted_password
+        send(Devise.password_field)[0,29] if send(Devise.password_field)
       end
 
       if Devise.activerecord51?
@@ -213,11 +213,11 @@ module Devise
 
       if Devise.activerecord51?
         def send_password_change_notification?
-          self.class.send_password_change_notification && saved_change_to_encrypted_password? && !@skip_password_change_notification
+          self.class.send_password_change_notification && send("saved_change_to_#{Devise.password_field}?") && !@skip_password_change_notification
         end
       else
         def send_password_change_notification?
-          self.class.send_password_change_notification && encrypted_password_changed? && !@skip_password_change_notification
+          self.class.send_password_change_notification && send("#{Devise.password_field}_changed?") && !@skip_password_change_notification
         end
       end
 

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -101,7 +101,7 @@ module Devise
 
         if Devise.activerecord51?
           def clear_reset_password_token?
-            encrypted_password_changed = respond_to?(:will_save_change_to_encrypted_password?) && will_save_change_to_encrypted_password?
+            encrypted_password_changed = respond_to?("will_save_change_to_#{Devise.password_field}?") && send("will_save_change_to_#{Devise.password_field}?")
             authentication_keys_changed = self.class.authentication_keys.any? do |attribute|
               respond_to?("will_save_change_to_#{attribute}?") && send("will_save_change_to_#{attribute}?")
             end
@@ -110,7 +110,7 @@ module Devise
           end
         else
           def clear_reset_password_token?
-            encrypted_password_changed = respond_to?(:encrypted_password_changed?) && encrypted_password_changed?
+            encrypted_password_changed = respond_to?("#{Devise.password_field}_changed?") && send("#{Devise.password_field}_changed?")
             authentication_keys_changed = self.class.authentication_keys.any? do |attribute|
               respond_to?("#{attribute}_changed?") && send("#{attribute}_changed?")
             end

--- a/lib/generators/active_record/devise_generator.rb
+++ b/lib/generators/active_record/devise_generator.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 <<RUBY
       ## Database authenticatable
       t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string :#{Devise.password_field}, null: false, default: ""
 
       ## Recoverable
       t.string   :reset_password_token

--- a/lib/generators/mongoid/devise_generator.rb
+++ b/lib/generators/mongoid/devise_generator.rb
@@ -24,7 +24,7 @@ module Mongoid
 <<RUBY
   ## Database authenticatable
   field :email,              type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field :#{Devise.password_field}, type: String, default: ""
 
   ## Recoverable
   field :reset_password_token,   type: String

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -122,6 +122,9 @@ Devise.setup do |config|
   # Send a notification email when the user's password is changed.
   # config.send_password_change_notification = false
 
+  # Use password_hash field instead of encrypted_password
+  # config.use_password_hash_field = true
+
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without
   # confirming their account. For instance, if set to 2.days, the user will be

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -103,31 +103,31 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
 
   test 'should generate a hashed password while setting password' do
     user = new_user
-    assert_present user.encrypted_password
+    assert_present user.send(Devise.password_field)
   end
 
   test 'should support custom hashing methods' do
     user = UserWithCustomHashing.new(password: '654321')
-    assert_equal user.encrypted_password, '123456'
+    assert_equal user.send(Devise.password_field), '123456'
   end
 
   test 'allow authenticatable_salt to work even with nil hashed password' do
     user = User.new
-    user.encrypted_password = nil
+    user.send("#{Devise.password_field}=", nil)
     assert_nil user.authenticatable_salt
   end
 
   test 'should not generate a hashed password if password is blank' do
-    assert_blank new_user(password: nil).encrypted_password
-    assert_blank new_user(password: '').encrypted_password
+    assert_blank new_user(password: nil).send(Devise.password_field)
+    assert_blank new_user(password: '').send(Devise.password_field)
   end
 
   test 'should hash password again if password has changed' do
     user = create_user
-    encrypted_password = user.encrypted_password
+    encrypted_password = user.send(Devise.password_field)
     user.password = user.password_confirmation = 'new_password'
     user.save!
-    assert_not_equal encrypted_password, user.encrypted_password
+    assert_not_equal encrypted_password, user.send(Devise.password_field)
   end
 
   test 'should test for a valid password' do
@@ -138,13 +138,13 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
 
   test 'should not raise error with an empty password' do
     user = create_user
-    user.encrypted_password = ''
+    user.send("#{Devise.password_field}=", '')
     assert_nothing_raised { user.valid_password?('12345678') }
   end
 
   test 'should be an invalid password if the user has an empty password' do
     user = create_user
-    user.encrypted_password = ''
+    user.send("#{Devise.password_field}=", '')
     refute user.valid_password?('654321')
   end
 
@@ -292,17 +292,17 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     assert !user.valid?
   end
 
-  test 'required_fields should be encryptable_password and the email field by default' do
+  test 'required_fields should be password and the email field by default' do
     assert_equal Devise::Models::DatabaseAuthenticatable.required_fields(User), [
-      :encrypted_password,
+      Devise.password_field,
       :email
     ]
   end
 
-  test 'required_fields should be encryptable_password and the login when the login is on authentication_keys' do
+  test 'required_fields should be password and the login when the login is on authentication_keys' do
     swap Devise, authentication_keys: [:login] do
       assert_equal Devise::Models::DatabaseAuthenticatable.required_fields(User), [
-        :encrypted_password,
+        Devise.password_field,
         :login
       ]
     end

--- a/test/models_test.rb
+++ b/test/models_test.rb
@@ -111,7 +111,7 @@ class CheckFieldsTest < ActiveSupport::TestCase
 
       devise :database_authenticatable
 
-      attr_accessor :encrypted_password, :email
+      attr_accessor Devise.password_field, :email
     end
 
     assert_nothing_raised do
@@ -129,7 +129,7 @@ class CheckFieldsTest < ActiveSupport::TestCase
 
       devise :database_authenticatable
 
-      attr_accessor :encrypted_password
+      attr_accessor Devise.password_field
     end
 
     assert_raise_with_message Devise::Models::MissingAttribute, "The following attribute(s) is (are) missing on your model: email" do
@@ -148,7 +148,7 @@ class CheckFieldsTest < ActiveSupport::TestCase
       devise :database_authenticatable
     end
 
-    assert_raise_with_message Devise::Models::MissingAttribute, "The following attribute(s) is (are) missing on your model: encrypted_password, email" do
+    assert_raise_with_message Devise::Models::MissingAttribute, "The following attribute(s) is (are) missing on your model: #{Devise.password_field}, email" do
       Devise::Models.check_fields!(Magician)
     end
   end

--- a/test/rails_app/app/mongoid/admin.rb
+++ b/test/rails_app/app/mongoid/admin.rb
@@ -9,7 +9,7 @@ class Admin
 
   ## Database authenticatable
   field :email,              type: String
-  field :encrypted_password, type: String
+  field Devise.password_field, type: String
 
   ## Recoverable
   field :reset_password_token,   type: String

--- a/test/rails_app/app/mongoid/user.rb
+++ b/test/rails_app/app/mongoid/user.rb
@@ -12,7 +12,7 @@ class User
 
   ## Database authenticatable
   field :email,              type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field Devise.password_field, type: String, default: ""
 
   ## Recoverable
   field :reset_password_token,   type: String

--- a/test/rails_app/app/mongoid/user_on_engine.rb
+++ b/test/rails_app/app/mongoid/user_on_engine.rb
@@ -12,7 +12,7 @@ class UserOnEngine
 
   ## Database authenticatable
   field :email, type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field Devise.password_field, type: String, default: ""
 
   ## Recoverable
   field :reset_password_token, type: String

--- a/test/rails_app/app/mongoid/user_on_main_app.rb
+++ b/test/rails_app/app/mongoid/user_on_main_app.rb
@@ -12,7 +12,7 @@ class UserOnMainApp
 
   ## Database authenticatable
   field :email, type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field Devise.password_field, type: String, default: ""
 
   ## Recoverable
   field :reset_password_token, type: String

--- a/test/rails_app/app/mongoid/user_with_validations.rb
+++ b/test/rails_app/app/mongoid/user_with_validations.rb
@@ -12,7 +12,7 @@ class UserWithValidations
 
   ## Database authenticatable
   field :email, type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field Devise.password_field, type: String, default: ""
 
   ## Recoverable
   field :reset_password_token, type: String

--- a/test/rails_app/app/mongoid/user_without_email.rb
+++ b/test/rails_app/app/mongoid/user_without_email.rb
@@ -12,7 +12,7 @@ class UserWithoutEmail
 
   ## Database authenticatable
   field :email, type: String, default: ""
-  field :encrypted_password, type: String, default: ""
+  field Devise.password_field, type: String, default: ""
 
   ## Recoverable
   field :reset_password_token, type: String

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -81,6 +81,9 @@ Devise.setup do |config|
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [:email]
 
+  # Use password_hash field instead of encrypted_password
+  config.use_password_hash_field = ENV["DEVISE_PASSWORD_HASH"].present?
+
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
   # config.remember_for = 2.weeks

--- a/test/rails_app/db/migrate/20100401102949_create_tables.rb
+++ b/test/rails_app/db/migrate/20100401102949_create_tables.rb
@@ -12,7 +12,7 @@ class CreateTables < superclass
 
       ## Database authenticatable
       t.string :email,              null: false, default: ""
-      t.string :encrypted_password, null: false, default: ""
+      t.string Devise.password_field, null: false, default: ""
 
       ## Recoverable
       t.string   :reset_password_token
@@ -45,7 +45,7 @@ class CreateTables < superclass
     create_table :admins do |t|
       ## Database authenticatable
       t.string :email,              null: true
-      t.string :encrypted_password, null: true
+      t.string Devise.password_field, null: true
 
       ## Recoverable
       t.string   :reset_password_token


### PR DESCRIPTION
Hi, thanks for this awesome gem.

This PR adds an option to use the `password_hash` field instead of `encrypted_password` with the intent to make it the default going forward (since Devise doesn't encrypt passwords).

```ruby
Devise.setup do |config|
  # Use password_hash field instead of encrypted_password
  config.use_password_hash_field = true
end
```

A few notes:

- I wanted to use the name `password_digest` to match Rails `has_secure_password`, but it looks like `password_digest(password)` is the public interface for custom hashing. Could also go with `hashed_password`.
- I tried using `alias_attribute` so `encrypted_password` would continue to work even when enabled (for cleaner code/better backwards compatibility), but it didn't play nicely with Mongoid (Mongoid requires attributes to be defined before they can be aliased). We could still include this for Active Record.
- I didn't want to blow up the test suite, so just added two tests to the build matrix.
- 3rd party libraries would want to use `Devise.password_field` going forward.

Let me know what you think.