### PR TITLE
Replace matcher `refute` to `assert_not`

### DIFF
--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -98,7 +98,7 @@ class ControllerAuthenticatableTest < Devise::ControllerTestCase
 
   test 'proxy admin_signed_in? to authenticatewith admin scope' do
     @mock_warden.expects(:authenticate).with(scope: :admin)
-    refute @controller.admin_signed_in?
+    assert_not @controller.admin_signed_in?
   end
 
   test 'proxy publisher_account_signed_in? to authenticate with namespaced publisher account scope' do
@@ -319,10 +319,10 @@ class ControllerAuthenticatableTest < Devise::ControllerTestCase
 
   test 'is_flashing_format? is guarded against flash (middleware) not being loaded' do
     @controller.request.expects(:respond_to?).with(:flash).returns(false)
-    refute @controller.is_flashing_format?
+    assert_not @controller.is_flashing_format?
   end
 
   test 'is not a devise controller' do
-    refute @controller.devise_controller?
+    assert_not @controller.devise_controller?
   end
 end

--- a/test/controllers/internal_helpers_test.rb
+++ b/test/controllers/internal_helpers_test.rb
@@ -121,7 +121,7 @@ class HelpersTest < Devise::ControllerTestCase
     MyController.send(:public, :navigational_formats)
 
     swap Devise, navigational_formats: ['*/*', :html] do
-      refute @controller.navigational_formats.include?("*/*")
+      assert_not @controller.navigational_formats.include?("*/*")
     end
 
     MyController.send(:protected, :navigational_formats)

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -71,8 +71,8 @@ class DeviseTest < ActiveSupport::TestCase
   test 'add new module using the helper method' do
     Devise.add_module(:coconut)
     assert_equal 1, Devise::ALL.select { |v| v == :coconut }.size
-    refute Devise::STRATEGIES.include?(:coconut)
-    refute defined?(Devise::Models::Coconut)
+    assert_not Devise::STRATEGIES.include?(:coconut)
+    assert_not defined?(Devise::Models::Coconut)
     Devise::ALL.delete(:coconut)
 
     Devise.add_module(:banana, strategy: :fruits)
@@ -88,11 +88,11 @@ class DeviseTest < ActiveSupport::TestCase
 
   test 'should complain when comparing empty or different sized passes' do
     [nil, ""].each do |empty|
-      refute Devise.secure_compare(empty, "something")
-      refute Devise.secure_compare("something", empty)
-      refute Devise.secure_compare(empty, empty)
+      assert_not Devise.secure_compare(empty, "something")
+      assert_not Devise.secure_compare("something", empty)
+      assert_not Devise.secure_compare(empty, empty)
     end
-    refute Devise.secure_compare("size_1", "size_four")
+    assert_not Devise.secure_compare("size_1", "size_four")
   end
 
   test 'Devise.email_regexp should match valid email addresses' do

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -6,7 +6,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
   test 'sign in should not run model validations' do
     sign_in_as_user
 
-    refute User.validations_performed
+    assert_not User.validations_performed
   end
 
   test 'home should be accessible without sign in' do
@@ -18,13 +18,13 @@ class AuthenticationSanityTest < Devise::IntegrationTest
   test 'sign in as user should not authenticate admin scope' do
     sign_in_as_user
     assert warden.authenticated?(:user)
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
   end
 
   test 'sign in as admin should not authenticate user scope' do
     sign_in_as_admin
     assert warden.authenticated?(:admin)
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test 'sign in as both user and admin at same time' do
@@ -39,7 +39,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
       sign_in_as_user
       sign_in_as_admin
       delete destroy_user_session_path
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
       assert warden.authenticated?(:admin)
     end
   end
@@ -50,7 +50,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
       sign_in_as_admin
 
       delete destroy_admin_session_path
-      refute warden.authenticated?(:admin)
+      assert_not warden.authenticated?(:admin)
       assert warden.authenticated?(:user)
     end
   end
@@ -61,8 +61,8 @@ class AuthenticationSanityTest < Devise::IntegrationTest
       sign_in_as_admin
 
       delete destroy_user_session_path
-      refute warden.authenticated?(:user)
-      refute warden.authenticated?(:admin)
+      assert_not warden.authenticated?(:user)
+      assert_not warden.authenticated?(:admin)
     end
   end
 
@@ -72,21 +72,21 @@ class AuthenticationSanityTest < Devise::IntegrationTest
       sign_in_as_admin
 
       delete destroy_admin_session_path
-      refute warden.authenticated?(:admin)
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:admin)
+      assert_not warden.authenticated?(:user)
     end
   end
 
   test 'not signed in as admin should not be able to access admins actions' do
     get admins_path
     assert_redirected_to new_admin_session_path
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
   end
 
   test 'signed in as user should not be able to access admins actions' do
     sign_in_as_user
     assert warden.authenticated?(:user)
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
 
     get admins_path
     assert_redirected_to new_admin_session_path
@@ -95,7 +95,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
   test 'signed in as admin should be able to access admin actions' do
     sign_in_as_admin
     assert warden.authenticated?(:admin)
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
 
     get admins_path
 
@@ -123,7 +123,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
 
     get root_path
     assert_contain 'Signed out successfully'
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
   end
 
   test 'unauthenticated admin set message on sign out' do
@@ -146,13 +146,13 @@ class AuthenticationRoutesRestrictions < Devise::IntegrationTest
   test 'not signed in should not be able to access private route (authenticate denied)' do
     get private_path
     assert_redirected_to new_admin_session_path
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
   end
 
   test 'signed in as user should not be able to access private route restricted to admins (authenticate denied)' do
     sign_in_as_user
     assert warden.authenticated?(:user)
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
     get private_path
     assert_redirected_to new_admin_session_path
   end
@@ -160,7 +160,7 @@ class AuthenticationRoutesRestrictions < Devise::IntegrationTest
   test 'signed in as admin should be able to access private route restricted to admins (authenticate accepted)' do
     sign_in_as_admin
     assert warden.authenticated?(:admin)
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
 
     get private_path
 
@@ -172,7 +172,7 @@ class AuthenticationRoutesRestrictions < Devise::IntegrationTest
   test 'signed in as inactive admin should not be able to access private/active route restricted to active admins (authenticate denied)' do
     sign_in_as_admin(active: false)
     assert warden.authenticated?(:admin)
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
 
     assert_raises ActionController::RoutingError do
       get "/private/active"
@@ -182,7 +182,7 @@ class AuthenticationRoutesRestrictions < Devise::IntegrationTest
   test 'signed in as active admin should be able to access private/active route restricted to active admins (authenticate accepted)' do
     sign_in_as_admin(active: true)
     assert warden.authenticated?(:admin)
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
 
     get private_active_path
 
@@ -194,7 +194,7 @@ class AuthenticationRoutesRestrictions < Devise::IntegrationTest
   test 'signed in as admin should get admin dashboard (authenticated accepted)' do
     sign_in_as_admin
     assert warden.authenticated?(:admin)
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
 
     get dashboard_path
 
@@ -206,7 +206,7 @@ class AuthenticationRoutesRestrictions < Devise::IntegrationTest
   test 'signed in as user should get user dashboard (authenticated accepted)' do
     sign_in_as_user
     assert warden.authenticated?(:user)
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
 
     get dashboard_path
 
@@ -224,7 +224,7 @@ class AuthenticationRoutesRestrictions < Devise::IntegrationTest
   test 'signed in as inactive admin should not be able to access dashboard/active route restricted to active admins (authenticated denied)' do
     sign_in_as_admin(active: false)
     assert warden.authenticated?(:admin)
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
 
     assert_raises ActionController::RoutingError do
       get "/dashboard/active"
@@ -234,7 +234,7 @@ class AuthenticationRoutesRestrictions < Devise::IntegrationTest
   test 'signed in as active admin should be able to access dashboard/active route restricted to active admins (authenticated accepted)' do
     sign_in_as_admin(active: true)
     assert warden.authenticated?(:admin)
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
 
     get dashboard_active_path
 
@@ -246,7 +246,7 @@ class AuthenticationRoutesRestrictions < Devise::IntegrationTest
   test 'signed in user should not see unauthenticated page (unauthenticated denied)' do
     sign_in_as_user
     assert warden.authenticated?(:user)
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
 
     assert_raises ActionController::RoutingError do
       get join_path
@@ -420,13 +420,13 @@ class AuthenticationOthersTest < Devise::IntegrationTest
   test 'handles unverified requests gets rid of caches' do
     swap ApplicationController, allow_forgery_protection: true do
       post exhibit_user_url(1)
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
 
       sign_in_as_user
       assert warden.authenticated?(:user)
 
       post exhibit_user_url(1)
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
       assert_equal "User is not authenticated", response.body
     end
   end
@@ -489,7 +489,7 @@ class AuthenticationOthersTest < Devise::IntegrationTest
   test 'uses the mapping from router' do
     sign_in_as_user visit: "/as/sign_in"
     assert warden.authenticated?(:user)
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
   end
 
   test 'sign in with xml format returns xml response' do
@@ -531,14 +531,14 @@ class AuthenticationOthersTest < Devise::IntegrationTest
     sign_in_as_user
     delete destroy_user_session_path(format: 'xml')
     assert_response :no_content
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test 'sign out with json format returns no content' do
     sign_in_as_user
     delete destroy_user_session_path(format: 'json')
     assert_response :no_content
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test 'sign out with non-navigational format via XHR does not redirect' do
@@ -546,7 +546,7 @@ class AuthenticationOthersTest < Devise::IntegrationTest
       sign_in_as_admin
       get destroy_sign_out_via_get_session_path, xhr: true, headers: { "HTTP_ACCEPT" => "application/json,text/javascript,*/*" } # NOTE: Bug is triggered by combination of XHR and */*.
       assert_response :no_content
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -556,7 +556,7 @@ class AuthenticationOthersTest < Devise::IntegrationTest
       sign_in_as_user
       delete destroy_user_session_path, xhr: true, headers: { "HTTP_ACCEPT" => "text/html,*/*" }
       assert_response :redirect
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 end
@@ -566,7 +566,7 @@ class AuthenticationKeysTest < Devise::IntegrationTest
     swap Devise, authentication_keys: [:subdomain] do
       sign_in_as_user
       assert_contain "Invalid Subdomain or password."
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -595,7 +595,7 @@ class AuthenticationRequestKeysTest < Devise::IntegrationTest
         sign_in_as_user
       end
 
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -605,7 +605,7 @@ class AuthenticationRequestKeysTest < Devise::IntegrationTest
     swap Devise, request_keys: [:subdomain] do
       sign_in_as_user
       assert_contain "Invalid Email or password."
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -628,7 +628,7 @@ class AuthenticationSignOutViaTest < Devise::IntegrationTest
   test 'allow sign out via delete when sign_out_via provides only delete' do
     sign_in!(:sign_out_via_delete)
     delete destroy_sign_out_via_delete_session_path
-    refute warden.authenticated?(:sign_out_via_delete)
+    assert_not warden.authenticated?(:sign_out_via_delete)
   end
 
   test 'do not allow sign out via get when sign_out_via provides only delete' do
@@ -642,7 +642,7 @@ class AuthenticationSignOutViaTest < Devise::IntegrationTest
   test 'allow sign out via post when sign_out_via provides only post' do
     sign_in!(:sign_out_via_post)
     post destroy_sign_out_via_post_session_path
-    refute warden.authenticated?(:sign_out_via_post)
+    assert_not warden.authenticated?(:sign_out_via_post)
   end
 
   test 'do not allow sign out via get when sign_out_via provides only post' do
@@ -656,13 +656,13 @@ class AuthenticationSignOutViaTest < Devise::IntegrationTest
   test 'allow sign out via delete when sign_out_via provides delete and post' do
     sign_in!(:sign_out_via_delete_or_post)
     delete destroy_sign_out_via_delete_or_post_session_path
-    refute warden.authenticated?(:sign_out_via_delete_or_post)
+    assert_not warden.authenticated?(:sign_out_via_delete_or_post)
   end
 
   test 'allow sign out via post when sign_out_via provides delete and post' do
     sign_in!(:sign_out_via_delete_or_post)
     post destroy_sign_out_via_delete_or_post_session_path
-    refute warden.authenticated?(:sign_out_via_delete_or_post)
+    assert_not warden.authenticated?(:sign_out_via_delete_or_post)
   end
 
   test 'do not allow sign out via get when sign_out_via provides delete and post' do

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -43,12 +43,12 @@ class ConfirmationTest < Devise::IntegrationTest
   test 'user with valid confirmation token should not be able to confirm an account after the token has expired' do
     swap Devise, confirm_within: 3.days do
       user = create_user(confirm: false, confirmation_sent_at: 4.days.ago)
-      refute user.confirmed?
+      assert_not user.confirmed?
       visit_user_confirmation_with_token(user.raw_confirmation_token)
 
       assert_have_selector '#error_explanation'
       assert_contain %r{needs to be confirmed within 3 days}
-      refute user.reload.confirmed?
+      assert_not user.reload.confirmed?
       assert_current_url "/users/confirmation?confirmation_token=#{user.raw_confirmation_token}"
     end
   end
@@ -86,7 +86,7 @@ class ConfirmationTest < Devise::IntegrationTest
   test 'user with valid confirmation token should be able to confirm an account before the token has expired' do
     swap Devise, confirm_within: 3.days do
       user = create_user(confirm: false, confirmation_sent_at: 2.days.ago)
-      refute user.confirmed?
+      assert_not user.confirmed?
       visit_user_confirmation_with_token(user.raw_confirmation_token)
 
       assert_contain 'Your email address has been successfully confirmed.'
@@ -132,7 +132,7 @@ class ConfirmationTest < Devise::IntegrationTest
       sign_in_as_user(confirm: false)
 
       assert_contain 'You have to confirm your email address before continuing'
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -143,7 +143,7 @@ class ConfirmationTest < Devise::IntegrationTest
       end
 
       assert_contain 'Invalid Email or password'
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -316,7 +316,7 @@ class ConfirmationOnChangeTest < Devise::IntegrationTest
     assert_contain 'Your email address has been successfully confirmed.'
     assert_current_url '/admin_area/sign_in'
     assert admin.reload.confirmed?
-    refute admin.reload.pending_reconfirmation?
+    assert_not admin.reload.pending_reconfirmation?
   end
 
   test 'admin with previously valid confirmation token should not be able to confirm email after email changed again' do
@@ -338,7 +338,7 @@ class ConfirmationOnChangeTest < Devise::IntegrationTest
     assert_contain 'Your email address has been successfully confirmed.'
     assert_current_url '/admin_area/sign_in'
     assert admin.reload.confirmed?
-    refute admin.reload.pending_reconfirmation?
+    assert_not admin.reload.pending_reconfirmation?
   end
 
   test 'admin email should be unique also within unconfirmed_email' do

--- a/test/integration/database_authenticatable_test.rb
+++ b/test/integration/database_authenticatable_test.rb
@@ -21,7 +21,7 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
         fill_in 'email', with: 'foo@bar.com'
       end
 
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -43,14 +43,14 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
         fill_in 'email', with: ' foo@bar.com '
       end
 
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
   test 'sign in should not authenticate if not using proper authentication keys' do
     swap Devise, authentication_keys: [:username] do
       sign_in_as_user
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -61,7 +61,7 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
       end
 
       assert_contain 'Invalid email address'
-      refute warden.authenticated?(:admin)
+      assert_not warden.authenticated?(:admin)
     end
   end
 
@@ -71,7 +71,7 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
     end
 
     assert_contain 'Invalid Email or password'
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
   end
 
   test 'when in paranoid mode and without a valid e-mail' do

--- a/test/integration/http_authenticatable_test.rb
+++ b/test/integration/http_authenticatable_test.rb
@@ -6,7 +6,7 @@ class HttpAuthenticationTest < Devise::IntegrationTest
   test 'sign in with HTTP should not run model validations' do
     sign_in_as_new_user_with_http
 
-    refute User.validations_performed
+    assert_not User.validations_performed
   end
 
   test 'handles unverified requests gets rid of caches but continues signed in' do

--- a/test/integration/lockable_test.rb
+++ b/test/integration/lockable_test.rb
@@ -87,7 +87,7 @@ class LockTest < Devise::IntegrationTest
 
     assert_current_url "/users/sign_in"
     assert_contain 'Your account has been unlocked successfully. Please sign in to continue.'
-    refute user.reload.access_locked?
+    assert_not user.reload.access_locked?
   end
 
   test "user should not send a new e-mail if already locked" do

--- a/test/integration/omniauthable_test.rb
+++ b/test/integration/omniauthable_test.rb
@@ -49,7 +49,7 @@ class OmniauthableIntegrationTest < Devise::IntegrationTest
       click_link "Sign in with FaceBook"
       assert warden.authenticated?(:user)
 
-      refute User.validations_performed
+      assert_not User.validations_performed
     end
   end
 
@@ -84,7 +84,7 @@ class OmniauthableIntegrationTest < Devise::IntegrationTest
     assert_current_url "/"
     assert_contain "You have signed up successfully."
     assert_contain "Hello User user@example.com"
-    refute session["devise.facebook_data"]
+    assert_not session["devise.facebook_data"]
   end
 
   test "cleans up session on cancel" do

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -12,7 +12,7 @@ class PasswordTest < Devise::IntegrationTest
   def request_forgot_password(&block)
     visit_new_password_path
     assert_response :success
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
 
     fill_in 'email', with: 'user@test.com'
     yield if block_given?
@@ -149,7 +149,7 @@ class PasswordTest < Devise::IntegrationTest
     assert_current_url '/users/password'
     assert_have_selector '#error_explanation'
     assert_contain %r{Reset password token(.*)invalid}
-    refute user.reload.valid_password?('987654321')
+    assert_not user.reload.valid_password?('987654321')
   end
 
   test 'not authenticated user with valid reset password token but invalid password should not be able to change their password' do
@@ -163,7 +163,7 @@ class PasswordTest < Devise::IntegrationTest
     assert_current_url '/users/password'
     assert_have_selector '#error_explanation'
     assert_contain "Password confirmation doesn't match Password"
-    refute user.reload.valid_password?('987654321')
+    assert_not user.reload.valid_password?('987654321')
   end
 
   test 'not authenticated user with valid data should be able to change their password' do
@@ -183,7 +183,7 @@ class PasswordTest < Devise::IntegrationTest
     reset_password {  fill_in 'Confirm new password', with: 'other_password' }
     assert_response :success
     assert_have_selector '#error_explanation'
-    refute user.reload.valid_password?('987654321')
+    assert_not user.reload.valid_password?('987654321')
 
     reset_password visit: false
     assert_contain 'Your password has been changed successfully.'

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -66,11 +66,11 @@ class RegistrationTest < Devise::IntegrationTest
     assert_not_contain 'You have to confirm your account before continuing'
     assert_current_url "/"
 
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
 
     user = User.to_adapter.find_first(order: [:id, :desc])
     assert_equal user.email, 'new_user@test.com'
-    refute user.confirmed?
+    assert_not user.confirmed?
   end
 
   test 'a guest user should receive the confirmation instructions from the default mailer' do
@@ -94,7 +94,7 @@ class RegistrationTest < Devise::IntegrationTest
     click_button 'Sign up'
 
     assert_current_url "/?custom=1"
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test 'a guest user cannot sign up with invalid information' do
@@ -116,7 +116,7 @@ class RegistrationTest < Devise::IntegrationTest
     assert_contain "2 errors prohibited"
     assert_nil User.to_adapter.find_first
 
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test 'a guest should not sign up with email/password that already exists' do
@@ -135,7 +135,7 @@ class RegistrationTest < Devise::IntegrationTest
     assert_current_url '/users'
     assert_contain(/Email.*already.*taken/)
 
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test 'a guest should not be able to change account' do
@@ -191,7 +191,7 @@ class RegistrationTest < Devise::IntegrationTest
 
       assert_contain 'Your account has been updated successfully, but since your password was changed, you need to sign in again'
       assert_equal new_user_session_path, @request.path
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -252,7 +252,7 @@ class RegistrationTest < Devise::IntegrationTest
     click_button 'Update'
 
     assert_contain "Password confirmation doesn't match Password"
-    refute User.to_adapter.find_first.valid_password?('pas123')
+    assert_not User.to_adapter.find_first.valid_password?('pas123')
   end
   
   test 'a signed in user should see a warning about minimum password length' do

--- a/test/integration/rememberable_test.rb
+++ b/test/integration/rememberable_test.rb
@@ -41,12 +41,12 @@ class RememberMeTest < Devise::IntegrationTest
   test 'handle unverified requests gets rid of caches' do
     swap ApplicationController, allow_forgery_protection: true do
       post exhibit_user_url(1)
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
 
       create_user_and_remember
       post exhibit_user_url(1)
       assert_equal "User is not authenticated", response.body
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 
@@ -59,8 +59,8 @@ class RememberMeTest < Devise::IntegrationTest
           authenticity_token: "oops",
           user: { email: "jose.valim@gmail.com", password: "123456", remember_me: "1" }
         }
-      refute warden.authenticated?(:user)
-      refute request.cookies['remember_user_token']
+      assert_not warden.authenticated?(:user)
+      assert_not request.cookies['remember_user_token']
     end
   end
 
@@ -140,7 +140,7 @@ class RememberMeTest < Devise::IntegrationTest
       get root_path
       current_remember_token = request.cookies['remember_user_token']
 
-      refute_equal old_remember_token, current_remember_token
+      assert_not_equal old_remember_token, current_remember_token
     end
   end
 
@@ -166,13 +166,13 @@ class RememberMeTest < Devise::IntegrationTest
     get root_path
     assert_response :success
     assert warden.authenticated?(:user)
-    refute warden.authenticated?(:admin)
+    assert_not warden.authenticated?(:admin)
   end
 
   test 'do not remember with invalid token' do
     create_user_and_remember('add')
     get users_path
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
     assert_redirected_to new_user_session_path
   end
 
@@ -180,7 +180,7 @@ class RememberMeTest < Devise::IntegrationTest
     create_user_and_remember
     swap Devise, remember_for: 0.days do
       get users_path
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
       assert_redirected_to new_user_session_path
     end
   end
@@ -191,11 +191,11 @@ class RememberMeTest < Devise::IntegrationTest
     assert warden.authenticated?(:user)
 
     delete destroy_user_session_path
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
     assert_nil warden.cookies['remember_user_token']
 
     get users_path
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test 'changing user password expires remember me token' do
@@ -205,7 +205,7 @@ class RememberMeTest < Devise::IntegrationTest
     user.save!
 
     get users_path
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test 'valid sign in calls after_remembered callback' do

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -58,7 +58,7 @@ class SessionTimeoutTest < Devise::IntegrationTest
 
       get users_path
       assert_redirected_to users_path
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
       assert warden.authenticated?(:admin)
     end
   end
@@ -72,8 +72,8 @@ class SessionTimeoutTest < Devise::IntegrationTest
       assert_not_nil last_request_at
 
       get root_path
-      refute warden.authenticated?(:user)
-      refute warden.authenticated?(:admin)
+      assert_not warden.authenticated?(:user)
+      assert_not warden.authenticated?(:admin)
     end
   end
 
@@ -110,7 +110,7 @@ class SessionTimeoutTest < Devise::IntegrationTest
 
     assert_response :success
     assert_contain 'Sign in'
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test 'time out is not triggered on sign in' do
@@ -136,7 +136,7 @@ class SessionTimeoutTest < Devise::IntegrationTest
       get expire_user_path(user)
       get users_path
       assert_redirected_to users_path
-      refute warden.authenticated?(:user)
+      assert_not warden.authenticated?(:user)
     end
   end
 

--- a/test/integration/trackable_test.rb
+++ b/test/integration/trackable_test.rb
@@ -6,7 +6,7 @@ class TrackableHooksTest < Devise::IntegrationTest
   test "trackable should not run model validations" do
     sign_in_as_user
 
-    refute User.validations_performed
+    assert_not User.validations_performed
   end
 
   test "current and last sign in timestamps are updated on each sign in" do

--- a/test/mapping_test.rb
+++ b/test/mapping_test.rb
@@ -117,7 +117,7 @@ class MappingTest < ActiveSupport::TestCase
     assert mapping.authenticatable?
     assert mapping.recoverable?
     assert mapping.lockable?
-    refute mapping.omniauthable?
+    assert_not mapping.omniauthable?
   end
 
   test 'find mapping by path' do

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -41,9 +41,9 @@ class ConfirmableTest < ActiveSupport::TestCase
   end
 
   test 'should verify whether a user is confirmed or not' do
-    refute new_user.confirmed?
+    assert_not new_user.confirmed?
     user = create_user
-    refute user.confirmed?
+    assert_not user.confirmed?
     user.confirm
     assert user.confirmed?
   end
@@ -53,7 +53,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     assert user.confirm
     assert_blank user.errors[:email]
 
-    refute user.confirm
+    assert_not user.confirm
     assert_equal "was already confirmed, please try signing in", user.errors[:email].join
   end
 
@@ -67,13 +67,13 @@ class ConfirmableTest < ActiveSupport::TestCase
 
   test 'should return a new record with errors when a invalid token is given' do
     confirmed_user = User.confirm_by_token('invalid_confirmation_token')
-    refute confirmed_user.persisted?
+    assert_not confirmed_user.persisted?
     assert_equal "is invalid", confirmed_user.errors[:confirmation_token].join
   end
 
   test 'should return a new record with errors when a blank token is given' do
     confirmed_user = User.confirm_by_token('')
-    refute confirmed_user.persisted?
+    assert_not confirmed_user.persisted?
     assert_equal "can't be blank", confirmed_user.errors[:confirmation_token].join
   end
 
@@ -82,7 +82,7 @@ class ConfirmableTest < ActiveSupport::TestCase
 
     confirmed_user = User.confirm_by_token('')
 
-    refute user.reload.confirmed?
+    assert_not user.reload.confirmed?
     assert_equal "can't be blank", confirmed_user.errors[:confirmation_token].join
   end
 
@@ -91,7 +91,7 @@ class ConfirmableTest < ActiveSupport::TestCase
 
     confirmed_user = User.confirm_by_token(nil)
 
-    refute user.reload.confirmed?
+    assert_not user.reload.confirmed?
     assert_equal "can't be blank", confirmed_user.errors[:confirmation_token].join
   end
 
@@ -145,7 +145,7 @@ class ConfirmableTest < ActiveSupport::TestCase
 
     assert_email_not_sent do
       user.save!
-      refute user.confirmed?
+      assert_not user.confirmed?
     end
   end
 
@@ -165,7 +165,7 @@ class ConfirmableTest < ActiveSupport::TestCase
 
   test 'should return a new user if no email was found' do
     confirmation_user = User.send_confirmation_instructions(email: "invalid@example.com")
-    refute confirmation_user.persisted?
+    assert_not confirmation_user.persisted?
   end
 
   test 'should add error to new user email if no email was found' do
@@ -212,7 +212,7 @@ class ConfirmableTest < ActiveSupport::TestCase
   test 'should not be able to send instructions if the user is already confirmed' do
     user = create_user
     user.confirm
-    refute user.resend_confirmation_instructions
+    assert_not user.resend_confirmation_instructions
     assert user.confirmed?
     assert_equal 'was already confirmed, please try signing in', user.errors[:email].join
   end
@@ -221,7 +221,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     swap Devise, allow_unconfirmed_access_for: 1.day do
       user = create_user
       user.confirmation_sent_at = 2.days.ago
-      refute user.active_for_authentication?
+      assert_not user.active_for_authentication?
 
       Devise.allow_unconfirmed_access_for = 3.days
       assert user.active_for_authentication?
@@ -237,14 +237,14 @@ class ConfirmableTest < ActiveSupport::TestCase
       assert user.active_for_authentication?
 
       user.confirmation_sent_at = 5.days.ago
-      refute user.active_for_authentication?
+      assert_not user.active_for_authentication?
     end
   end
 
   test 'should be active when already confirmed' do
     user = create_user
-    refute user.confirmed?
-    refute user.active_for_authentication?
+    assert_not user.confirmed?
+    assert_not user.active_for_authentication?
 
     user.confirm
     assert user.confirmed?
@@ -255,7 +255,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     Devise.allow_unconfirmed_access_for = 0.days
     user = create_user
     user.confirmation_sent_at = Time.zone.today
-    refute user.active_for_authentication?
+    assert_not user.active_for_authentication?
   end
 
   test 'should not be active when confirm period is set to 0 days' do
@@ -264,7 +264,7 @@ class ConfirmableTest < ActiveSupport::TestCase
 
     Timecop.freeze(Time.zone.today) do
       user.confirmation_sent_at = Time.zone.today
-      refute user.active_for_authentication?
+      assert_not user.active_for_authentication?
     end
   end
 
@@ -280,7 +280,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     user = create_user
     user.confirmation_sent_at = nil
     user.save
-    refute user.reload.active_for_authentication?
+    assert_not user.reload.active_for_authentication?
   end
 
   test 'should be active without confirmation when confirmation is not required' do
@@ -313,7 +313,7 @@ class ConfirmableTest < ActiveSupport::TestCase
     swap Devise, confirmation_keys: [:username, :email] do
       user = create_user
       confirm_user = User.send_confirmation_instructions(email: user.email)
-      refute confirm_user.persisted?
+      assert_not confirm_user.persisted?
       assert_equal "can't be blank", confirm_user.errors[:username].join
     end
   end
@@ -338,7 +338,7 @@ class ConfirmableTest < ActiveSupport::TestCase
 
   test 'should not accept confirmation email token after 4 days when expiration is set to 3 days' do
     swap Devise, confirm_within: 3.days do
-      refute confirm_user_by_token_with_confirmation_sent_at(4.days.ago)
+      assert_not confirm_user_by_token_with_confirmation_sent_at(4.days.ago)
     end
   end
 
@@ -378,14 +378,14 @@ class ConfirmableTest < ActiveSupport::TestCase
       self.username = self.username.to_s + 'updated'
     end
     old = user.username
-    refute user.confirm
+    assert_not user.confirm
     assert_equal user.username, old
   end
 
   test 'should always perform validations upon confirm when ensure valid true' do
     admin = create_admin
     admin.stubs(:valid?).returns(false)
-    refute admin.confirm(ensure_valid: true)
+    assert_not admin.confirm(ensure_valid: true)
   end
 end
 
@@ -411,7 +411,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
     admin.skip_reconfirmation!
     assert admin.update(email: 'new_test@example.com')
     assert admin.confirmed?
-    refute admin.pending_reconfirmation?
+    assert_not admin.pending_reconfirmation?
     assert_equal original_token, admin.confirmation_token
   end
 
@@ -502,7 +502,7 @@ class ReconfirmableTest < ActiveSupport::TestCase
 
   test 'should return a new admin if no email or unconfirmed_email was found' do
     confirmation_admin = Admin.send_confirmation_instructions(email: "invalid@email.com")
-    refute confirmation_admin.persisted?
+    assert_not confirmation_admin.persisted?
   end
 
   test 'should add error to new admin email if no email or unconfirmed_email was found' do

--- a/test/models/database_authenticatable_test.rb
+++ b/test/models/database_authenticatable_test.rb
@@ -133,7 +133,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
   test 'should test for a valid password' do
     user = create_user
     assert user.valid_password?('12345678')
-    refute user.valid_password?('654321')
+    assert_not user.valid_password?('654321')
   end
 
   test 'should not raise error with an empty password' do
@@ -145,7 +145,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
   test 'should be an invalid password if the user has an empty password' do
     user = create_user
     user.encrypted_password = ''
-    refute user.valid_password?('654321')
+    assert_not user.valid_password?('654321')
   end
 
   test 'should respond to current password' do
@@ -161,7 +161,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
 
   test 'should add an error to current password when it is invalid' do
     user = create_user
-    refute user.update_with_password(current_password: 'other',
+    assert_not user.update_with_password(current_password: 'other',
       password: 'pass4321', password_confirmation: 'pass4321')
     assert user.reload.valid_password?('12345678')
     assert_match "is invalid", user.errors[:current_password].join
@@ -169,7 +169,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
 
   test 'should add an error to current password when it is blank' do
     user = create_user
-    refute user.update_with_password(password: 'pass4321',
+    assert_not user.update_with_password(password: 'pass4321',
       password_confirmation: 'pass4321')
     assert user.reload.valid_password?('12345678')
     assert_match "can't be blank", user.errors[:current_password].join
@@ -179,7 +179,7 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
     user = UserWithValidation.create!(valid_attributes)
     user.save
     assert user.persisted?
-    refute user.update_with_password(username: "")
+    assert_not user.update_with_password(username: "")
     assert_match "usertest", user.reload.username
     assert_match "can't be blank", user.errors[:username].join
   end
@@ -192,14 +192,14 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
 
   test 'should not update password with invalid confirmation' do
     user = create_user
-    refute user.update_with_password(current_password: '12345678',
+    assert_not user.update_with_password(current_password: '12345678',
       password: 'pass4321', password_confirmation: 'other')
     assert user.reload.valid_password?('12345678')
   end
 
   test 'should clean up password fields on failure' do
     user = create_user
-    refute user.update_with_password(current_password: '12345678',
+    assert_not user.update_with_password(current_password: '12345678',
       password: 'pass4321', password_confirmation: 'other')
     assert user.password.blank?
     assert user.password_confirmation.blank?
@@ -226,14 +226,14 @@ class DatabaseAuthenticatableTest < ActiveSupport::TestCase
 
   test 'should not destroy user with invalid password' do
     user = create_user
-    refute user.destroy_with_password('other')
+    assert_not user.destroy_with_password('other')
     assert user.persisted?
     assert_match "is invalid", user.errors[:current_password].join
   end
 
   test 'should not destroy user with blank password' do
     user = create_user
-    refute user.destroy_with_password(nil)
+    assert_not user.destroy_with_password(nil)
     assert user.persisted?
     assert_match "can't be blank", user.errors[:current_password].join
   end

--- a/test/models/lockable_test.rb
+++ b/test/models/lockable_test.rb
@@ -59,7 +59,7 @@ class LockableTest < ActiveSupport::TestCase
 
   test "should verify whether a user is locked or not" do
     user = create_user
-    refute user.access_locked?
+    assert_not user.access_locked?
     user.lock_access!
     assert user.access_locked?
   end
@@ -69,7 +69,7 @@ class LockableTest < ActiveSupport::TestCase
     user.confirm
     assert user.active_for_authentication?
     user.lock_access!
-    refute user.active_for_authentication?
+    assert_not user.active_for_authentication?
   end
 
   test "should unlock a user by cleaning locked_at, failed_attempts and unlock_token" do
@@ -85,7 +85,7 @@ class LockableTest < ActiveSupport::TestCase
   end
 
   test "new user should not be locked and should have zero failed_attempts" do
-    refute new_user.access_locked?
+    assert_not new_user.access_locked?
     assert_equal 0, create_user.failed_attempts
   end
 
@@ -96,7 +96,7 @@ class LockableTest < ActiveSupport::TestCase
       assert user.access_locked?
 
       Devise.unlock_in = 1.hour
-      refute user.access_locked?
+      assert_not user.access_locked?
     end
   end
 
@@ -175,18 +175,18 @@ class LockableTest < ActiveSupport::TestCase
     raw  = user.send_unlock_instructions
     locked_user = User.unlock_access_by_token(raw)
     assert_equal locked_user, user
-    refute user.reload.access_locked?
+    assert_not user.reload.access_locked?
   end
 
   test 'should return a new record with errors when a invalid token is given' do
     locked_user = User.unlock_access_by_token('invalid_token')
-    refute locked_user.persisted?
+    assert_not locked_user.persisted?
     assert_equal "is invalid", locked_user.errors[:unlock_token].join
   end
 
   test 'should return a new record with errors when a blank token is given' do
     locked_user = User.unlock_access_by_token('')
-    refute locked_user.persisted?
+    assert_not locked_user.persisted?
     assert_equal "can't be blank", locked_user.errors[:unlock_token].join
   end
 
@@ -199,7 +199,7 @@ class LockableTest < ActiveSupport::TestCase
 
   test 'should return a new user if no email was found' do
     unlock_user = User.send_unlock_instructions(email: "invalid@example.com")
-    refute unlock_user.persisted?
+    assert_not unlock_user.persisted?
   end
 
   test 'should add error to new user email if no email was found' do
@@ -219,23 +219,23 @@ class LockableTest < ActiveSupport::TestCase
     swap Devise, unlock_keys: [:username, :email] do
       user = create_user
       unlock_user = User.send_unlock_instructions(email: user.email)
-      refute unlock_user.persisted?
+      assert_not unlock_user.persisted?
       assert_equal "can't be blank", unlock_user.errors[:username].join
     end
   end
 
   test 'should not be able to send instructions if the user is not locked' do
     user = create_user
-    refute user.resend_unlock_instructions
-    refute user.access_locked?
+    assert_not user.resend_unlock_instructions
+    assert_not user.access_locked?
     assert_equal 'was not locked', user.errors[:email].join
   end
 
   test 'should not be able to send instructions if the user if not locked and have username as unlock key' do
     swap Devise, unlock_keys: [:username] do
       user = create_user
-      refute user.resend_unlock_instructions
-      refute user.access_locked?
+      assert_not user.resend_unlock_instructions
+      assert_not user.access_locked?
       assert_equal 'was not locked', user.errors[:username].join
     end
   end

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -94,14 +94,14 @@ class RecoverableTest < ActiveSupport::TestCase
     user = create_user
     user.send_reset_password_instructions
     assert_present user.reset_password_token
-    refute user.reset_password('123456789', '987654321')
+    assert_not user.reset_password('123456789', '987654321')
     assert_present user.reset_password_token
   end
 
   test 'should not reset password with invalid data' do
     user = create_user
     user.stubs(:valid?).returns(false)
-    refute user.reset_password('123456789', '987654321')
+    assert_not user.reset_password('123456789', '987654321')
   end
 
   test 'should reset reset password token and send instructions by email' do
@@ -121,7 +121,7 @@ class RecoverableTest < ActiveSupport::TestCase
 
   test 'should return a new record with errors if user was not found by e-mail' do
     reset_password_user = User.send_reset_password_instructions(email: "invalid@example.com")
-    refute reset_password_user.persisted?
+    assert_not reset_password_user.persisted?
     assert_equal "not found", reset_password_user.errors[:email].join
   end
 
@@ -137,7 +137,7 @@ class RecoverableTest < ActiveSupport::TestCase
       swap Devise, reset_password_keys: [:username, :email] do
           user = create_user
           reset_password_user = User.send_reset_password_instructions(email: user.email)
-          refute reset_password_user.persisted?
+          assert_not reset_password_user.persisted?
           assert_equal "can't be blank", reset_password_user.errors[:username].join
       end
   end
@@ -166,13 +166,13 @@ class RecoverableTest < ActiveSupport::TestCase
 
   test 'should return a new record with errors if no reset_password_token is found' do
     reset_password_user = User.reset_password_by_token(reset_password_token: 'invalid_token')
-    refute reset_password_user.persisted?
+    assert_not reset_password_user.persisted?
     assert_equal "is invalid", reset_password_user.errors[:reset_password_token].join
   end
 
   test 'should return a new record with errors if reset_password_token is blank' do
     reset_password_user = User.reset_password_by_token(reset_password_token: '')
-    refute reset_password_user.persisted?
+    assert_not reset_password_user.persisted?
     assert_match "can't be blank", reset_password_user.errors[:reset_password_token].join
   end
 
@@ -181,7 +181,7 @@ class RecoverableTest < ActiveSupport::TestCase
     raw  = user.send_reset_password_instructions
 
     reset_password_user = User.reset_password_by_token(reset_password_token: raw, password: '')
-    refute reset_password_user.errors.empty?
+    assert_not reset_password_user.errors.empty?
     assert_match "can't be blank", reset_password_user.errors[:password].join
     assert_equal raw, reset_password_user.reset_password_token
   end
@@ -191,7 +191,7 @@ class RecoverableTest < ActiveSupport::TestCase
     raw  = user.send_reset_password_instructions
 
     reset_password_user = User.reset_password_by_token(reset_password_token: raw)
-    refute reset_password_user.errors.empty?
+    assert_not reset_password_user.errors.empty?
     assert_match "can't be blank", reset_password_user.errors[:password].join
     assert_equal raw, reset_password_user.reset_password_token
   end
@@ -209,7 +209,7 @@ class RecoverableTest < ActiveSupport::TestCase
     assert_nil reset_password_user.reset_password_token
 
     user.reload
-    refute user.valid_password?(old_password)
+    assert_not user.valid_password?(old_password)
     assert user.valid_password?('new_password')
     assert_nil user.reset_password_token
   end
@@ -231,7 +231,7 @@ class RecoverableTest < ActiveSupport::TestCase
       user.reload
 
       assert user.valid_password?(old_password)
-      refute user.valid_password?('new_password')
+      assert_not user.valid_password?('new_password')
       assert_equal "has expired, please request a new one", reset_password_user.errors[:reset_password_token].join
     end
   end

--- a/test/models/timeoutable_test.rb
+++ b/test/models/timeoutable_test.rb
@@ -9,11 +9,11 @@ class TimeoutableTest < ActiveSupport::TestCase
   end
 
   test 'should not be expired' do
-    refute new_user.timedout?(29.minutes.ago)
+    assert_not new_user.timedout?(29.minutes.ago)
   end
 
   test 'should not be expired when params is nil' do
-    refute new_user.timedout?(nil)
+    assert_not new_user.timedout?(nil)
   end
 
   test 'should use timeout_in method' do
@@ -21,23 +21,23 @@ class TimeoutableTest < ActiveSupport::TestCase
     user.instance_eval { def timeout_in; 10.minutes end }
 
     assert user.timedout?(12.minutes.ago)
-    refute user.timedout?(8.minutes.ago)
+    assert_not user.timedout?(8.minutes.ago)
   end
 
   test 'should not be expired when timeout_in method returns nil' do
     user = new_user
     user.instance_eval { def timeout_in; nil end }
-    refute user.timedout?(10.hours.ago)
+    assert_not user.timedout?(10.hours.ago)
   end
 
   test 'fallback to Devise config option' do
     swap Devise, timeout_in: 1.minute do
       user = new_user
       assert user.timedout?(2.minutes.ago)
-      refute user.timedout?(30.seconds.ago)
+      assert_not user.timedout?(30.seconds.ago)
 
       Devise.timeout_in = 5.minutes
-      refute user.timedout?(2.minutes.ago)
+      assert_not user.timedout?(2.minutes.ago)
       assert user.timedout?(6.minutes.ago)
     end
   end

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -99,7 +99,7 @@ class ValidatableTest < ActiveSupport::TestCase
 
     user.password_confirmation = 'confirmation'
     assert user.invalid?
-    refute (user.errors[:password].join =~ /is too long/)
+    assert_not (user.errors[:password].join =~ /is too long/)
   end
 
   test 'should complain about length even if password is not required' do

--- a/test/models_test.rb
+++ b/test/models_test.rb
@@ -15,7 +15,7 @@ class ActiveRecordTest < ActiveSupport::TestCase
     end
 
     (Devise::ALL - modules).each do |mod|
-      refute include_module?(klass, mod)
+      assert_not include_module?(klass, mod)
     end
   end
 

--- a/test/test/integration_helpers_test.rb
+++ b/test/test/integration_helpers_test.rb
@@ -18,7 +18,7 @@ class TestIntegrationsHelpersTest < Devise::IntegrationTest
     sign_out user
 
     visit '/'
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
   end
 
   test '#sign_out does not signs out other scopes' do
@@ -28,7 +28,7 @@ class TestIntegrationsHelpersTest < Devise::IntegrationTest
 
     visit '/'
 
-    refute warden.authenticated?(:user)
+    assert_not warden.authenticated?(:user)
     assert warden.authenticated?(:admin)
   end
 end


### PR DESCRIPTION
This PR changed matcher `refute` to `assert_not`.
- refute -> assert_not
- refute_equal -> assert_not_equal

This is because `assert_not` style was preferred in this repository. #5157
