### PR TITLE
Feature: Supporting Multipart and plain text emails

### DIFF
--- a/app/mailers/devise/mailer.rb
+++ b/app/mailers/devise/mailer.rb
@@ -26,5 +26,15 @@ if defined?(ActionMailer)
     def password_change(record, opts={})
       devise_mail(record, :password_change, opts)
     end
+
+    def lookup_context
+      details = details_for_lookup.dup
+      details[:formats] = []
+      details[:formats] << :text if Devise.mailer_formats.include?(:text)
+      details[:formats] << :html if Devise.mailer_formats.include?(:html)
+
+      @_lookup_context ||=
+        ActionView::LookupContext.new(self.class._view_paths, details, _prefixes)
+    end
   end
 end

--- a/app/views/devise/mailer/confirmation_instructions.text.erb
+++ b/app/views/devise/mailer/confirmation_instructions.text.erb
@@ -1,0 +1,3 @@
+Welcome <%= @email %>!
+
+You can confirm your account email through visiting the url <%= confirmation_url(@resource, confirmation_token: @token) %>

--- a/app/views/devise/mailer/email_changed.text.erb
+++ b/app/views/devise/mailer/email_changed.text.erb
@@ -1,0 +1,7 @@
+Hello <%= @email %>!
+
+<% if @resource.try(:unconfirmed_email?) %>
+  We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.
+<% else %>
+  We're contacting you to notify you that your email has been changed to <%= @resource.email %>.
+<% end %>

--- a/app/views/devise/mailer/password_change.text.erb
+++ b/app/views/devise/mailer/password_change.text.erb
@@ -1,0 +1,3 @@
+Hello <%= @resource.email %>!
+
+We're contacting you to notify you that your password has been changed.

--- a/app/views/devise/mailer/reset_password_instructions.text.erb
+++ b/app/views/devise/mailer/reset_password_instructions.text.erb
@@ -1,0 +1,8 @@
+Hello <%= @resource.email %>!
+
+Someone has requested a link to change your password. You can do this through the by visiting the url below.
+
+<%= edit_password_url(@resource, reset_password_token: @token) %>
+
+If you didn't request this, please ignore this email.
+Your password won't change until you access the link above and create a new one.

--- a/app/views/devise/mailer/unlock_instructions.text.erb
+++ b/app/views/devise/mailer/unlock_instructions.text.erb
@@ -1,0 +1,7 @@
+Hello <%= @resource.email %>!
+
+Your account has been locked due to an excessive number of unsuccessful sign in attempts.
+
+Visit the url below to unlock your account:
+
+<%= unlock_url(@resource, unlock_token: @token) %>

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -211,6 +211,10 @@ module Devise
   mattr_accessor :mailer_sender
   @@mailer_sender = nil
 
+  # Which formats should Devise send as emails
+  mattr_accessor :mailer_formats
+  @@mailer_formats = [:html]
+
   # Skip session storage for the following strategies
   mattr_accessor :skip_session_storage
   @@skip_session_storage = [:http_auth]

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -26,6 +26,11 @@ Devise.setup do |config|
   # with default "from" parameter.
   config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
 
+  # Configure which formats the Devise mailer will include for notification emails.
+  # Currently supports html and text. For backwards compatability, the default is html
+  # The text format is it's own template, there is no automatic geneneration from html.
+  # config.mailer_formats = [:html, :text]
+
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
 

--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -17,4 +17,14 @@ class MailerTest < ActionMailer::TestCase
 
     assert mail.content_transfer_encoding, "7bit"
   end
+
+  test "emails multi-part if mailer_formats contains multiple formats" do
+    begin
+      Devise.mailer_formats = [:html, :text]
+      mail = Devise::Mailer.email_changed(create_user)
+      assert mail.multipart?
+    ensure
+      Devise.mailer_formats = [:html]
+    end
+  end
 end

--- a/test/rails_app/app/views/users/mailer/email_changed.html.erb
+++ b/test/rails_app/app/views/users/mailer/email_changed.html.erb
@@ -1,0 +1,1 @@
+email changed html

--- a/test/rails_app/app/views/users/mailer/email_changed.text.erb
+++ b/test/rails_app/app/views/users/mailer/email_changed.text.erb
@@ -1,0 +1,1 @@
+email changed text


### PR DESCRIPTION
Addresses #5034

The additional overrides were required in order to maintain the current 'html only' behavior, making this a fully opt-in feature.

Very open to directions/options from the community before merging.

On a sidenote, I think we could also handle scoped views in a similar fashion (overriding the `lookup_context`)