### PR TITLE
fix keyword arguments for future compatibility

### DIFF
--- a/test/support/http_method_compatibility.rb
+++ b/test/support/http_method_compatibility.rb
@@ -11,7 +11,7 @@ module Devise
           if options.empty?
             super url
           else
-            super url, options
+            super url, **options
           end
         end
       else
@@ -36,7 +36,7 @@ module Devise
           if options.empty?
             super action
           else
-            super action, options
+            super action, **options
           end
         end
       else


### PR DESCRIPTION
Hi, thanks for your great effort to maintain this gem!

## summary
Just found out a warning about keyword arguments that will potentially break with future ruby, when trying to test devise against Ruby2.7.
(thankfully the prior PR #5174 covered most of them - examining the test logs that I ran with my forked repo, this seems the only one left out)

## why it's needed to change
Devise::IntegrationTest and Devise::ControllerTestCase offers sets of methods that delegate its execution to ActionController::TestCase.

As the delegated methods (and its delegated one, #process) require [keyword arguments](https://github.com/rails/rails/blob/09cc7967b970373de8a748f68d027ec4bf331832/actionpack/lib/action_controller/test_case.rb#L389-L411), we need to pass our hash objects as keyword arguments.

## compatibility
Lots of corner cases have been discussed around this issue, luckily this patch is perfectly compatible with the current implementation, except for the deprecation warnings emitted by the existing codes (when being run on Ruby2.7).

Specifically:

- When keyword arguments or hash object are provided
  - devise helper methods delegate its argument and keyword arguments to ActionController::TestCase#get, #post, etc.
  - for current implementation, warnings are emitted with Ruby2.7

- When no keyword arguments are given
  1.  with < Ruby2.7
       - both implementation (current vs new) passes its argument with empty hash.
  2.  with Ruby2.7.0
      - both implementation (current vs new) passes its argument only. the behavior differs from that of older rubies, but both new and current implementation shows this behavior change. Delegated methods can run without problems in all versions of Ruby.

the latter case is the only corner case. With Ruby < 2.7, we pass over empty hash to ActionController::TestCase, but it does no harm as it is interpreted as empty keyword args with < Ruby 2.7.

## backup
To demonstrate how they compare (and for my own peace of mind), I created a few delegation test cases - emulating [current implementation](https://github.com/fursich/keyword_arguments/blob/master/test/positional_arguments_test.rb), and [new implementation](https://github.com/fursich/keyword_arguments/blob/master/test/keyword_arguments_test.rb) , as well as cases about how they [compare against each other](https://github.com/fursich/keyword_arguments/blob/master/test/comparison_test.rb)

These cases are tested against Ruby2.1.10 upto 2.7.0 with similar environment with devise. [Please feel free to check](https://travis-ci.org/fursich/keyword_arguments/builds/630667308?utm_source=github_status&utm_medium=notification) in case you are interested ;)

Hope that helps!