### PR TITLE
Respect @skip_email_changed_notification in overridden method.

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -310,7 +310,7 @@ module Devise
         # requests the email change, instead of when the change is confirmed.
         def send_email_changed_notification?
           if self.class.reconfirmable
-            self.class.send_email_changed_notification && reconfirmation_required?
+            !@skip_email_changed_notification && self.class.send_email_changed_notification && reconfirmation_required?
           else
             super
           end


### PR DESCRIPTION
The flag for skipping email change notification introduced in #4824 is ignored in this override of `send_email_changed_notification?`. When using both, DatabaseAuthenticatable and Confirmable, calling `skip_email_changed_notification!` won’t keep the notification from being sent.