### PR TITLE
Performance improvement for timeoutable

### DIFF
--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -21,8 +21,8 @@ Warden::Manager.after_set_user do |record, warden, options|
 
     proxy = Devise::Hooks::Proxy.new(warden)
 
-    if record.timedout?(last_request_at) &&
-        !env['devise.skip_timeout'] &&
+    if !env['devise.skip_timeout'] &&
+        record.timedout?(last_request_at) &&
         !proxy.remember_me_is_active?(record)
       Devise.sign_out_all_scopes ? proxy.sign_out : proxy.sign_out(scope)
       throw :warden, scope: scope, message: :timeout


### PR DESCRIPTION
move timeout_skip check earlier to avoid unnecessary record lookup