### PR TITLE
Add config setting to disable authenticating when calling current_user

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -297,6 +297,10 @@ module Devise
   mattr_accessor :sign_in_after_change_password
   @@sign_in_after_change_password = true
 
+  # When set to true, calling current_user will attempt to authenticate the user
+  mattr_accessor :current_user_attempts_login
+  @@current_user_attempts_login = true
+
   def self.rails51? # :nodoc:
     Rails.gem_version >= Gem::Version.new("5.1.x")
   end

--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -61,7 +61,7 @@ module Devise
               mappings = #{mappings}
               mappings.unshift mappings.delete(favourite.to_sym) if favourite
               mappings.each do |mapping|
-                current = warden.authenticate(scope: mapping)
+                current = Devise.current_user_attempts_login ? warden.authenticate(scope: mapping) : warden.user(mapping)
                 return current if current
               end
               nil
@@ -69,7 +69,7 @@ module Devise
 
             def current_#{group_name.to_s.pluralize}
               #{mappings}.map do |mapping|
-                warden.authenticate(scope: mapping)
+                Devise.current_user_attempts_login ? warden.authenticate(scope: mapping) : warden.user(mapping)
               end.compact
             end
 

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -92,6 +92,9 @@ Devise.setup do |config|
   # Does not affect registerable.
   # config.paranoid = true
 
+  # Calling current_user will attempt to authorize the user with warden. True by default.
+  # config.current_user_attemps_login = true
+
   # By default Devise will store the user in session. You can skip storage for
   # particular strategies by setting this option.
   # Notice that if you are skipping storage for all authentication paths, you

--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -58,6 +58,24 @@ class ControllerAuthenticatableTest < Devise::ControllerTestCase
     @controller.current_commenters
   end
 
+  test 'proxy current_[group] to get user with each scope' do
+    Devise.current_user_attempts_login = false
+    [:user, :admin].each do |scope|
+      @mock_warden.expects(:user).with(scope).returns(nil)
+    end
+    @controller.current_commenter
+    Devise.current_user_attempts_login = true
+  end
+
+  test 'proxy current_[plural_group] to get user with each scope' do
+    Devise.current_user_attempts_login = false
+    [:user, :admin].each do |scope|
+      @mock_warden.expects(:user).with(scope)
+    end
+    @controller.current_commenters
+    Devise.current_user_attempts_login = true
+  end
+
   test 'proxy current_publisher_account to authenticate with namespaced publisher account scope' do
     @mock_warden.expects(:authenticate).with(scope: :publisher_account)
     @controller.current_publisher_account


### PR DESCRIPTION
This addresses the discussion in #4951. I understand the desire to keep the behavior as is since it's been in the code base for over 10 years and is used in who knows how many different systems. That being said, I still see the value in not automatically authenticating the user when calling `current_user`. You can read the discussion in #4951 for both sides of the argument.

This pull request introduces an opt-in config setting to disable automatic authentication when calling `current_user`. This has no change for users that don't opt-in to this setting.

I will be honest, I am not happy with the testing that I added. It should probably be reviewed and improved by someone more familiar with the Devise internals than me.