### PR TITLE
Clarify DatabaseAuthenticable's behaviour for password fields

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -7,9 +7,9 @@ module Devise
     # Authenticatable Module, responsible for hashing the password and
     # validating the authenticity of a user while signing in.
     #
-    # This module overrides the `password=` method and skips setting the password
-    # when Rails is setting attributes, instead it hashes the plaintext password
-    # and stores it in `encrypted_password` for legacy reasons.
+    # This module defines a `password=` method. This method will hash the argument
+    # and store it in the `encrypted_password` column, bypassing any pre-existing
+    # `password` column if it exists.
     #
     # == Options
     #

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -7,6 +7,10 @@ module Devise
     # Authenticatable Module, responsible for hashing the password and
     # validating the authenticity of a user while signing in.
     #
+    # This module overrides the `password=` method and skips setting the password
+    # when Rails is setting attributes, instead it hashes the plaintext password
+    # and stores it in `encrypted_password` for legacy reasons.
+    #
     # == Options
     #
     # DatabaseAuthenticatable adds the following options to devise_for:


### PR DESCRIPTION
`DatabaseAuthenticable` overrides the `password=` method in a model, bypassing setting that attribute, and this should be reflected in the documentation.

We got bitten by this at work because we're using a legacy database where the User model already has a `password` field and upon the introduction of Devise the password stopped being stored there; we had to override the method again to get our needed behaviour but having this in the documentation would've saved us a few hours of debugging.

Thanks!