### PR TITLE
Fix kwargs usage for Ruby 2.7

### DIFF
--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -31,8 +31,8 @@ module Devise
       end
 
       # Override process to consider warden.
-      def process(*)
-        _catch_warden { super }
+      def process(action, **args)
+        _catch_warden { super(action, **args) }
 
         @response
       end


### PR DESCRIPTION
Fix one deprecation warning. This prevents us from using behavior that was deprecated in Ruby 2.7.