### PR TITLE
Fix Deprecation warning: Expected string default value for '--orm'

### DIFF
--- a/lib/generators/devise/devise_generator.rb
+++ b/lib/generators/devise/devise_generator.rb
@@ -13,7 +13,7 @@ module Devise
       desc "Generates a model with the given NAME (if one does not exist) with devise " \
            "configuration plus a migration file and devise routes."
 
-      hook_for :orm
+      hook_for :orm, required: true, desc: "ORM to be invoked"
 
       class_option :routes, desc: "Generate routes", type: :boolean, default: true
 

--- a/lib/generators/devise/devise_generator.rb
+++ b/lib/generators/devise/devise_generator.rb
@@ -13,7 +13,7 @@ module Devise
       desc "Generates a model with the given NAME (if one does not exist) with devise " \
            "configuration plus a migration file and devise routes."
 
-      hook_for :orm, required: true, desc: "ORM to be invoked"
+      hook_for :orm, type: :boolean
 
       class_option :routes, desc: "Generate routes", type: :boolean, default: true
 


### PR DESCRIPTION
Hi,

I use the `devise` and [`devise-specs`](https://github.com/andrii/devise-specs) gems.
And I checked with `byebug` to discover where was located this bug.

In https://github.com/andrii/devise-specs/blob/master/lib/devise/specs/railtie.rb, the problem goes with this line:

```ruby
        require 'generators/devise/devise_generator'
```

So the `devise_generator.rb` file is being called https://github.com/heartcombo/devise/blob/master/lib/generators/devise/devise_generator.rb

And this error is finally being raised:

```bash
rails generate devise:specs User
Deprecation warning: Expected string default value for '--orm'; got false (boolean).
This will be rejected in the future unless you explicitly pass the options `check_default_type: false` or call `allow_incompatible_default_type!` in your code
You can silence deprecations warning by setting the environment variable THOR_SILENCE_DEPRECATION.
```

Fixed with the commit below.

I use the same code as here: https://github.com/rails/rails/blob/master/railties/lib/rails/generators/rails/application_record/application_record_generator.rb

Thanks,
HLFH