### PR TITLE
Remove unused method from Devise::Generators::InstallGenerator

### DIFF
--- a/lib/generators/devise/install_generator.rb
+++ b/lib/generators/devise/install_generator.rb
@@ -37,10 +37,6 @@ module Devise
       def show_readme
         readme "README" if behavior == :invoke
       end
-
-      def rails_4?
-        Rails::VERSION::MAJOR == 4
-      end
     end
   end
 end


### PR DESCRIPTION
`rails_4?` is not called anymore since 2024fca4dfa3323070c3477e262b8422cadf6a42.
