### PR TITLE
Issue 5234 fix. Deprecated warning at controller_helpers.rb

### DIFF
--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -37,6 +37,8 @@ module Devise
         @response
       end
 
+      ruby2_keywords(:process) if respond_to?(:ruby2_keywords, true)
+
       # We need to set up the environment variables and the response in the controller.
       def setup_controller_for_warden #:nodoc:
         @request.env['action_controller.instance'] = @controller


### PR DESCRIPTION
## Environment

- Ruby **2.7.1**
- Rails **6.0.3**
- Devise **master** (March 8 2020)

## Current behavior
`~/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/devise-70f3ae24e009/lib/devise/test/controller_helpers.rb:36: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
~/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/rails-controller-testing-a60b3da1c1c7/lib/rails/controller/testing/template_assertions.rb:60: warning: The called method process' is defined here`