### PR TITLE
Skip lockable hook with skip_lockable set

### DIFF
--- a/lib/devise/hooks/lockable.rb
+++ b/lib/devise/hooks/lockable.rb
@@ -3,7 +3,10 @@
 # After each sign in, if resource responds to failed_attempts, sets it to 0
 # This is only triggered when the user is explicitly set (with set_user)
 Warden::Manager.after_set_user except: :fetch do |record, warden, options|
-  if record.respond_to?(:failed_attempts) && warden.authenticated?(options[:scope])
+  if record.respond_to?(:failed_attempts) &&
+     warden.authenticated?(options[:scope]) &&
+     !warden.request.env['devise.skip_lockable']
+
     unless record.failed_attempts.to_i.zero?
       record.failed_attempts = 0
       record.save(validate: false)

--- a/test/integration/lockable_test.rb
+++ b/test/integration/lockable_test.rb
@@ -239,4 +239,21 @@ class LockTest < Devise::IntegrationTest
     end
   end
 
+  test "with skip_lockable, user failed attempts should not be cleared" do
+    user = create_user
+    user.update!(failed_attempts: 1)
+
+    sign_in_as_user do
+      header 'devise.skip_lockable', '1'
+    end
+
+    assert_equal 1, user.reload.failed_attempts
+    delete destroy_user_session_path
+
+    sign_in_as_user do
+      header 'devise.skip_lockable', false
+    end
+
+    assert_equal 0, user.reload.failed_attempts
+  end
 end


### PR DESCRIPTION
Fixes #5239

There are times where it it's not ideal to update the target record in
this hook. Introducing this option allows a developer to choose not to
update the record if they so desire.