### PR TITLE
remove useless rails51? method

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -297,10 +297,6 @@ module Devise
   mattr_accessor :sign_in_after_change_password
   @@sign_in_after_change_password = true
 
-  def self.rails51? # :nodoc:
-    Rails.gem_version >= Gem::Version.new("5.1.x")
-  end
-
   def self.activerecord51? # :nodoc:
     defined?(ActiveRecord) && ActiveRecord.gem_version >= Gem::Version.new("5.1.x")
   end


### PR DESCRIPTION
`self.rails51?` method is not using in `lib`, and the Only `test` uses the method.
I guess better to remove this method.