### PR TITLE
Fix warning from `thor`

### DIFF
--- a/lib/generators/devise/devise_generator.rb
+++ b/lib/generators/devise/devise_generator.rb
@@ -13,7 +13,7 @@ module Devise
       desc "Generates a model with the given NAME (if one does not exist) with devise " \
            "configuration plus a migration file and devise routes."
 
-      hook_for :orm, type: :boolean
+      hook_for :orm, required: true
 
       class_option :routes, desc: "Generate routes", type: :boolean, default: true
 


### PR DESCRIPTION
The `:orm` option can also have symbol values.

Fixes https://github.com/heartcombo/devise/issues/5252.