### PR TITLE
Increase the default minimum password length from 6 to 8

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -117,7 +117,7 @@ module Devise
 
   # Range validation for password length
   mattr_accessor :password_length
-  @@password_length = 6..128
+  @@password_length = 8..128
 
   # The time the user will be remembered without asking for credentials again.
   mattr_accessor :remember_for

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -12,7 +12,7 @@ module Devise
     # Validatable adds the following options to devise_for:
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
-    #   * +password_length+: a range expressing password length. Defaults to 6..128.
+    #   * +password_length+: a range expressing password length. Defaults to 8..128.
     #
     module Validatable
       # All validations used by this module.

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly


### PR DESCRIPTION
Increasing the minimum password length from 6 to 8 was done in 2012 (https://github.com/heartcombo/devise/commit/c179cef365f7188c91cbbc3db924a9f1f9563c3c#diff-ee89a7275db7a2af385d05e737aa11f8). This change was subsequently reverted but the default in the initializer template was uncommented (https://github.com/heartcombo/devise/commit/bdf0bc7b1e66d1a70e4ecda8507145658a4f1a96).

Since the value in the initializer has been uncommented for so long, there should be little chance of this update causing a breaking change.