### PR TITLE
serializable_hash deeper dup

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -104,7 +104,7 @@ module Devise
       # given to :except will simply add names to exempt to Devise internal list.
       def serializable_hash(options = nil)
         options = options.try(:dup) || {}
-        options[:except] = Array(options[:except])
+        options[:except] = Array(options[:except]).dup
 
         if options[:force_except]
           options[:except].concat Array(options[:force_except])

--- a/test/models/serializable_test.rb
+++ b/test/models/serializable_test.rb
@@ -43,7 +43,7 @@ class SerializableTest < ActiveSupport::TestCase
   end
 
   test 'should accept frozen options' do
-    assert_key "username", @user.as_json({only: :username}.freeze)["user"]
+    assert_key "username", @user.as_json({ only: :username, except: [:email].freeze }.freeze)["user"]
   end
 
   def assert_key(key, subject)


### PR DESCRIPTION
I ran into an issue where options[:except] is a frozen array, which explodes when we try to concat values in `serializable_hash`.  This also means that we're generally modifying the passed in value, despite the `dup`, since it's shallow. To fix this, could we do a deep dup?

alternatively, we could do:
```
options[:except] = Array(options[:except]).dup
```