### PR TITLE
Fix email submit on transaction rollback

### DIFF
--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -32,8 +32,13 @@ module Devise
       extend ActiveSupport::Concern
 
       included do
-        after_update :send_email_changed_notification, if: :send_email_changed_notification?
-        after_update :send_password_change_notification, if: :send_password_change_notification?
+        if defined?(ActiveRecord) && self < ActiveRecord::Base # ActiveRecord
+          after_commit :send_email_changed_notification, on: :update, if: :send_email_changed_notification?
+          after_commit :send_password_change_notification, on: :update, if: :send_password_change_notification?
+        else # Mongoid
+          after_update :send_email_changed_notification, if: :send_email_changed_notification?
+          after_update :send_password_change_notification, if: :send_password_change_notification?
+        end
 
         attr_reader :password, :current_password
         attr_accessor :password_confirmation
@@ -42,7 +47,7 @@ module Devise
       def initialize(*args, &block)
         @skip_email_changed_notification = false
         @skip_password_change_notification = false
-        super 
+        super
       end
 
       # Skips sending the email changed notification after_update


### PR DESCRIPTION
Hello
I noticed that some emails are submitted on after_update callbacks which can produce invalid emails if transaction is rolled back. I wanted to fix it using same approach like in `lib/devise/models/confirmable.rb`. Unfortunately some test are failing because of the order of callbacks. It may be related to https://github.com/rails/rails/issues/20911 but I'm not sure how to fix that.