### PR TITLE
Allow mailer methods to receive a block

### DIFF
--- a/app/mailers/devise/mailer.rb
+++ b/app/mailers/devise/mailer.rb
@@ -4,27 +4,27 @@ if defined?(ActionMailer)
   class Devise::Mailer < Devise.parent_mailer.constantize
     include Devise::Mailers::Helpers
 
-    def confirmation_instructions(record, token, opts = {})
+    def confirmation_instructions(record, token, opts = {}, &block)
       @token = token
-      devise_mail(record, :confirmation_instructions, opts)
+      devise_mail(record, :confirmation_instructions, opts, &block)
     end
 
-    def reset_password_instructions(record, token, opts = {})
+    def reset_password_instructions(record, token, opts = {}, &block)
       @token = token
-      devise_mail(record, :reset_password_instructions, opts)
+      devise_mail(record, :reset_password_instructions, opts, &block)
     end
 
-    def unlock_instructions(record, token, opts = {})
+    def unlock_instructions(record, token, opts = {}, &block)
       @token = token
-      devise_mail(record, :unlock_instructions, opts)
+      devise_mail(record, :unlock_instructions, opts, &block)
     end
 
-    def email_changed(record, opts = {})
-      devise_mail(record, :email_changed, opts)
+    def email_changed(record, opts = {}, &block)
+      devise_mail(record, :email_changed, opts, &block)
     end
 
-    def password_change(record, opts = {})
-      devise_mail(record, :password_change, opts)
+    def password_change(record, opts = {}, &block)
+      devise_mail(record, :password_change, opts, &block)
     end
   end
 end


### PR DESCRIPTION
Since the internal method `devise_mail` takes a block and ActionMailer's `mail` takes a block, I thought that it made sense for the devise mailer methods to also receive a block to make format overrides a bit easier.