### PR TITLE
chore: Cleanup old rack/rails session bug fix

### DIFF
--- a/lib/devise/controllers/sign_in_out.rb
+++ b/lib/devise/controllers/sign_in_out.rb
@@ -106,10 +106,12 @@ module Devise
       private
 
       def expire_data_after_sign_in!
+        # TODO: remove once Rails 5.2+ and forward are only supported.
         # session.keys will return an empty array if the session is not yet loaded.
         # This is a bug in both Rack and Rails.
         # A call to #empty? forces the session to be loaded.
         session.empty?
+
         session.keys.grep(/^devise\./).each { |k| session.delete(k) }
       end
 


### PR DESCRIPTION
Seven years ago rails `session.keys` could be empty if the session was not loaded yet.

To prevent an error the removed code was introduced
https://github.com/heartcombo/devise/issues/2660

Since then rails changed the behavior and makes sure that the session is loaded before someone wants to access any session keys
https://github.com/rails/rails/blob/3c99817394f634710a6280c5d5512c0ea663bce3/actionpack/lib/action_dispatch/request/session.rb#L120

Which means the `session.empty?` is not needed anymore