### PR TITLE
Add missing period to devise.registrations.updated_but_not_signed_in

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
       signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
       update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirmation link to confirm your new email address."
       updated: "Your account has been updated successfully."
-      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again"
+      updated_but_not_signed_in: "Your account has been updated successfully, but since your password was changed, you need to sign in again."
     sessions:
       signed_in: "Signed in successfully."
       signed_out: "Signed out successfully."

--- a/test/integration/registerable_test.rb
+++ b/test/integration/registerable_test.rb
@@ -189,7 +189,7 @@ class RegistrationTest < Devise::IntegrationTest
       fill_in 'current password', with: '12345678'
       click_button 'Update'
 
-      assert_contain 'Your account has been updated successfully, but since your password was changed, you need to sign in again'
+      assert_contain 'Your account has been updated successfully, but since your password was changed, you need to sign in again.'
       assert_equal new_user_session_path, @request.path
       refute warden.authenticated?(:user)
     end


### PR DESCRIPTION
Added missing full stop "." on registrations.updated_but_not_signed_in.