### PR TITLE
Fix kwargs usage for Ruby 2.7

### DIFF
--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -31,7 +31,7 @@ module Devise
       end
 
       # Override process to consider warden.
-      def process(*)
+      def process(*, **)
         _catch_warden { super }
 
         @response


### PR DESCRIPTION
This updates controller_helpers.rb so that the `process` method is
compatible with other controller helpers in Ruby 2.7.