### PR TITLE
More consistent use of `#set_flash_message!`

### DIFF
--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -8,7 +8,7 @@ class Devise::OmniauthCallbacksController < DeviseController
   end
 
   def failure
-    set_flash_message! :alert, :failure, kind: OmniAuth::Utils.camelize(failed_strategy.name), reason: failure_message
+    set_flash_message!(:alert, :failure, kind: OmniAuth::Utils.camelize(failed_strategy.name), reason: failure_message)
     redirect_to after_omniauth_failure_path_for(resource_name)
   end
 

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -64,7 +64,7 @@ class Devise::PasswordsController < DeviseController
     # Check if a reset_password_token is provided in the request
     def assert_reset_token_passed
       if params[:reset_password_token].blank?
-        set_flash_message(:alert, :no_token)
+        set_flash_message!(:alert, :no_token)
         redirect_to new_session_path(resource_name)
       end
     end

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -20,11 +20,11 @@ class Devise::RegistrationsController < DeviseController
     yield resource if block_given?
     if resource.persisted?
       if resource.active_for_authentication?
-        set_flash_message! :notice, :signed_up
+        set_flash_message!(:notice, :signed_up)
         sign_up(resource_name, resource)
         respond_with resource, location: after_sign_up_path_for(resource)
       else
-        set_flash_message! :notice, :"signed_up_but_#{resource.inactive_message}"
+        set_flash_message!(:notice, :"signed_up_but_#{resource.inactive_message}")
         expire_data_after_sign_in!
         respond_with resource, location: after_inactive_sign_up_path_for(resource)
       end
@@ -65,7 +65,7 @@ class Devise::RegistrationsController < DeviseController
   def destroy
     resource.destroy
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
-    set_flash_message! :notice, :destroyed
+    set_flash_message!(:notice, :destroyed)
     yield resource if block_given?
     respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
   end
@@ -148,8 +148,6 @@ class Devise::RegistrationsController < DeviseController
   private
 
   def set_flash_message_for_update(resource, prev_unconfirmed_email)
-    return unless is_flashing_format?
-
     flash_key = if update_needs_confirmation?(resource, prev_unconfirmed_email)
                   :update_needs_confirmation
                 elsif sign_in_after_change_password?
@@ -157,7 +155,7 @@ class Devise::RegistrationsController < DeviseController
                 else
                   :updated_but_not_signed_in
                 end
-    set_flash_message :notice, flash_key
+    set_flash_message!(:notice, flash_key)
   end
 
   def sign_in_after_change_password?

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -26,7 +26,7 @@ class Devise::SessionsController < DeviseController
   # DELETE /resource/sign_out
   def destroy
     signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
-    set_flash_message! :notice, :signed_out if signed_out
+    set_flash_message!(:notice, :signed_out if signed_out)
     yield if block_given?
     respond_to_on_destroy
   end
@@ -60,7 +60,7 @@ class Devise::SessionsController < DeviseController
   # to the after_sign_out path.
   def verify_signed_out_user
     if all_signed_out?
-      set_flash_message! :notice, :already_signed_out
+      set_flash_message!(:notice, :already_signed_out)
 
       respond_to_on_destroy
     end

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -26,7 +26,7 @@ class Devise::UnlocksController < DeviseController
     yield resource if block_given?
 
     if resource.errors.empty?
-      set_flash_message! :notice, :unlocked
+      set_flash_message!(:notice, :unlocked)
       respond_with_navigational(resource){ redirect_to after_unlock_path_for(resource) }
     else
       respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }

--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -112,7 +112,7 @@ MESSAGE
     end
 
     if authenticated && resource = warden.user(resource_name)
-      set_flash_message(:alert, 'already_authenticated', scope: 'devise.failure')
+      set_flash_message!(:alert, 'already_authenticated', scope: 'devise.failure')
       redirect_to after_sign_in_path_for(resource)
     end
   end
@@ -129,7 +129,7 @@ MESSAGE
     end
 
     if notice
-      set_flash_message! :notice, notice
+      set_flash_message!(:notice, notice)
       true
     end
   end


### PR DESCRIPTION
When using devise on an API only rails application some controllers still tried to add to the `request.flash` object.

- Use `#set_flash_message!` instead of `#set_flash_message` in `app/controllers/devise_controller.rb`, `app/controllers/devise/passwords_controller.rb`, and `app/controllers/devise/registrations_controller.rb`.
- Consistently use parenthesis when calling `#set_flash_message!`.