### PR TITLE
Clarify Turbo vs Turbolinks requirements

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -297,7 +297,8 @@ Devise.setup do |config|
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 
   # ==> Turbolinks configuration
-  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
+  # If your app is using Turbolinks (but *not* Turbo), Turbolinks::Controller needs
+  # to be included to make redirection work correctly:
   #
   # ActiveSupport.on_load(:devise_failure_app) do
   #   include Turbolinks::Controller


### PR DESCRIPTION
Follow up to https://github.com/heartcombo/devise/pull/4678

I spent a long time digging around the `Turbo` source code looking for a `Turbolinks::Controller` equivalent while trying to do an upgrade, then I realised is no longer necessary.