### PR TITLE
Respond form submission errors with 422 status code

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -14,7 +14,7 @@ class Devise::ConfirmationsController < DeviseController
     if successfully_sent?(resource)
       respond_with({}, location: after_resending_confirmation_instructions_path_for(resource_name))
     else
-      respond_with(resource)
+      respond_with(resource, status: :unprocessable_entity)
     end
   end
 

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -18,7 +18,7 @@ class Devise::PasswordsController < DeviseController
     if successfully_sent?(resource)
       respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
     else
-      respond_with(resource)
+      respond_with(resource, status: :unprocessable_entity)
     end
   end
 
@@ -47,7 +47,7 @@ class Devise::PasswordsController < DeviseController
       respond_with resource, location: after_resetting_password_path_for(resource)
     else
       set_minimum_password_length
-      respond_with resource
+      respond_with resource, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -31,7 +31,7 @@ class Devise::RegistrationsController < DeviseController
     else
       clean_up_passwords resource
       set_minimum_password_length
-      respond_with resource
+      respond_with resource, status: :unprocessable_entity
     end
   end
 
@@ -57,7 +57,7 @@ class Devise::RegistrationsController < DeviseController
     else
       clean_up_passwords resource
       set_minimum_password_length
-      respond_with resource
+      respond_with resource, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -16,7 +16,7 @@ class Devise::UnlocksController < DeviseController
     if successfully_sent?(resource)
       respond_with({}, location: after_sending_unlock_instructions_path_for(resource))
     else
-      respond_with(resource)
+      respond_with(resource, status: :unprocessable_entity)
     end
   end
 


### PR DESCRIPTION
Seems like Rails new convention will be returning 422 on form submission errors https://github.com/rails/rails/pull/41026 . It'd be a good idea to wait and see if that Rails PR is merged thus making official the new "convention". The root reason behind the change is supporting Turbo.

More info:
- https://github.com/hotwired/turbo/pull/39
- https://github.com/hotwired/turbo/issues/22#issuecomment-750336078