### PR TITLE
Extract kwargs to fix 2.7 warnings

### DIFF
--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -31,7 +31,7 @@ module Devise
       end
 
       # Override process to consider warden.
-      def process(*)
+      def process(*, **)
         _catch_warden { super }
 
         @response


### PR DESCRIPTION
The ControllerHelpers#process method simply propagates the invokation to another caller, for example to https://github.com/rails/rails-controller-testing/blob/4b15c86e82ee380f2a7cc009e470368f7520560a/lib/rails/controller/testing/template_assertions.rb#L60

This commit extracts kwargs from args in order to handle them properly