### PR TITLE
Update omniauthable tests for OmniAuth 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "responders", "~> 3.0"
 
 group :test do
   gem "omniauth-facebook"
-  gem "omniauth-openid"
+  gem "omniauth-openid", git: 'https://github.com/jkowens/omniauth-openid', branch: 'patch-1'
   gem "timecop"
   gem "webrat", "0.7.3", require: false
   gem "mocha", "~> 1.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: https://github.com/rails/activemodel-serializers-xml.git
+  remote: git://github.com/rails/activemodel-serializers-xml.git
   revision: 694f4071c6b16e4c8597cc323c241b5f787b3ea8
   specs:
     activemodel-serializers-xml (1.0.2)
@@ -8,13 +8,22 @@ GIT
       builder (~> 3.1)
 
 GIT
-  remote: https://github.com/rails/rails-controller-testing.git
+  remote: git://github.com/rails/rails-controller-testing.git
   revision: 4b15c86e82ee380f2a7cc009e470368f7520560a
   specs:
     rails-controller-testing (1.0.5)
       actionpack (>= 5.0.1.rc1)
       actionview (>= 5.0.1.rc1)
       activesupport (>= 5.0.1.rc1)
+
+GIT
+  remote: https://github.com/jkowens/omniauth-openid
+  revision: c70d35f266a814340b01f6f5649bb664a78743f4
+  branch: patch-1
+  specs:
+    omniauth-openid (2.0.0)
+      omniauth (>= 1.0, < 3.0)
+      rack-openid (~> 1.4.0)
 
 PATH
   remote: .
@@ -89,8 +98,11 @@ GEM
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     erubi (1.9.0)
-    faraday (1.0.1)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
+      ruby2_keywords
+    faraday-net_http (1.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (4.1.0)
@@ -122,22 +134,22 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.9.1)
+    omniauth (2.0.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
+      rack-protection
     omniauth-facebook (7.0.0)
       omniauth-oauth2 (~> 1.2)
-    omniauth-oauth2 (1.7.0)
+    omniauth-oauth2 (1.7.1)
       oauth2 (~> 1.4)
-      omniauth (~> 1.9)
-    omniauth-openid (1.0.1)
-      omniauth (~> 1.0)
-      rack-openid (~> 1.3.1)
+      omniauth (>= 1.9, < 3)
     orm_adapter (0.5.0)
     rack (2.2.3)
-    rack-openid (1.3.1)
+    rack-openid (1.4.2)
       rack (>= 1.1.0)
       ruby-openid (>= 2.1.8)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.3)
@@ -172,6 +184,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     ruby-openid (2.9.2)
+    ruby2_keywords (0.0.2)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -206,7 +219,7 @@ DEPENDENCIES
   omniauth
   omniauth-facebook
   omniauth-oauth2
-  omniauth-openid
+  omniauth-openid!
   rails (~> 6.0.0)
   rails-controller-testing!
   rdoc

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,6 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
   <% end %>
 <% end %>


### PR DESCRIPTION
Hope this helps with https://github.com/heartcombo/devise/pull/5327. Updated omniauthable links to use `method: :post` and revised corresponding tests.  I opened a PR with omniauth-openid (https://github.com/omniauth/omniauth-openid/pull/44), but for now I updated the Gemfile to pull it from a branch on my fork.