### PR TITLE
Fix Rails default log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ If you enable the [Recoverable](http://rubydoc.info/github/heartcombo/devise/mas
 1. Action Mailer logs the entire contents of all outgoing emails to the DEBUG level. Password reset tokens delivered to users in email will be leaked.
 2. Active Job logs all arguments to every enqueued job at the INFO level. If you configure Devise to use `deliver_later` to send password reset emails, password reset tokens will be leaked.
 
-Rails sets the production logger level to DEBUG by default. Consider changing your production logger level to WARN if you wish to prevent tokens from being leaked into your logs. In `config/environments/production.rb`:
+Rails sets the production logger level to INFO by default. Consider changing your production logger level to WARN if you wish to prevent tokens from being leaked into your logs. In `config/environments/production.rb`:
 
 ```ruby
 config.log_level = :warn


### PR DESCRIPTION
This changed in https://github.com/rails/rails/commit/229fd2a02fc694b4b7756445b6647777aa94e25d - the advice about changing your log level still stands though.