### PR TITLE
typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You will usually want to write tests for your changes.  To run the test suite, g
 Devise works with multiple Ruby and Rails versions, and ActiveRecord and Mongoid ORMs, which means you can run the test suite with some modifiers: `DEVISE_ORM` and `BUNDLE_GEMFILE`.
 
 ### DEVISE_ORM
-Since Devise support both Mongoid and ActiveRecord, we rely on this variable to run specific code for each ORM.
+Since Devise supports both Mongoid and ActiveRecord, we rely on this variable to run specific code for each ORM.
 The default value of `DEVISE_ORM` is `active_record`. To run the tests for Mongoid, you can pass `mongoid`:
 ```
 DEVISE_ORM=mongoid bin/test


### PR DESCRIPTION
changed 'support' to 'supports'