### PR TITLE
Enable the latest version of OmniAuth library

### DIFF
--- a/lib/devise/omniauth.rb
+++ b/lib/devise/omniauth.rb
@@ -8,7 +8,7 @@ rescue LoadError
   raise
 end
 
-unless OmniAuth::VERSION =~ /^1\./
+unless OmniAuth::VERSION =~ /^[1-2]\./
   raise "You are using an old OmniAuth version, please ensure you have 1.0.0.pr2 version or later installed."
 end
 


### PR DESCRIPTION
https://github.com/omniauth/omniauth

Error from application that is trying to use OmniAuth >= `2.0`:
```
/gems/ruby-2.6.6/gems/devise-4.7.3/lib/devise/omniauth.rb:12:in `<top (required)>': You are using an old OmniAuth version, please ensure you have 1.0.0.pr2 version or later installed. (RuntimeError)
```

`Gemfile.lock` for application that throws error:
```
    devise (4.7.3)
      bcrypt (~> 3.0)
      orm_adapter (~> 0.1)
      railties (>= 4.1.0)
      responders
      warden (~> 1.2.3)
    omniauth (2.0.1)
      hashie (>= 3.4.6)
      rack (>= 1.6.2, < 3)
      rack-protection
```
