### PR TITLE
Update omniauth constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem "rails", "~> 6.1.0"
-gem "omniauth"
+gem "omniauth", "~> 1.0"
 gem "omniauth-oauth2"
 gem "rdoc"
 

--- a/lib/devise/omniauth.rb
+++ b/lib/devise/omniauth.rb
@@ -9,7 +9,7 @@ rescue LoadError
 end
 
 unless OmniAuth::VERSION =~ /^1\./
-  raise "You are using an old OmniAuth version, please ensure you have 1.0.0.pr2 version or later installed."
+  raise "You are using an unsupported OmniAuth version, please ensure you have a version between 1.0.0.pr2 and <2.0.0 installed."
 end
 
 # Clean up the default path_prefix. It will be automatically set by Devise.


### PR DESCRIPTION
The error for an old version of omniauth is raised, when in fact the version is too new.

This changes the error message, and adds a version constraint to the gem in the Gemfile for development.