### PR TITLE
In rails 6.1 and later, `validates_uniqueness_of` does not specify the` case_sensitive` option.

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -301,6 +301,10 @@ module Devise
     defined?(ActiveRecord) && ActiveRecord.gem_version >= Gem::Version.new("5.1.x")
   end
 
+  def self.activerecord61? # :nodoc:
+    defined?(ActiveRecord) && ActiveRecord.gem_version >= Gem::Version.new("6.1.x")
+  end
+
   # Default way to set up Devise. Run rails generate devise_install to create
   # a fresh initializer with all configuration values.
   def self.setup

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -29,7 +29,10 @@ module Devise
 
         base.class_eval do
           validates_presence_of   :email, if: :email_required?
-          if Devise.activerecord51?
+          if Devise.activerecord61?
+            validates_uniqueness_of :email, allow_blank: true, if: :will_save_change_to_email?
+            validates_format_of     :email, with: email_regexp, allow_blank: true, if: :will_save_change_to_email?
+          elsif Devise.activerecord51?
             validates_uniqueness_of :email, allow_blank: true, case_sensitive: true, if: :will_save_change_to_email?
             validates_format_of     :email, with: email_regexp, allow_blank: true, if: :will_save_change_to_email?
           else


### PR DESCRIPTION
Thanks for creating this amazing gem.
When I was using this gem in my project, I found one problem, so I created this PR.

## Issue

In Mysql, by forcing `case_sensitive: ture`
Problems such as inconsistency in operation due to inconsistency with performance and DB constraints occur.
See the commit message below for more information.

https://github.com/rails/rails/commit/9def05385f1cfa41924bb93daa187615e88c95b9

## Expect

As a solution to the above problem, since Rails 6.1, the validator has been modified to respect the default database collation.

See: https://github.com/rails/rails/commit/3daf2c7b2df8014c928f5640376550191ab712b7

I would like to remove the `case_sensitive` option specification in this source code accordingly.


## Details

I currently specify the `case_sensitive` option as` validates_uniqueness_of` validate, but after investigating why I set it, it seemed that the goal was to suppress deprecated warnings.

See: https://github.com/heartcombo/devise/pull/5065