### PR TITLE
Fix bugs in `extend_remember_period`

### DIFF
--- a/lib/devise/hooks/rememberable.rb
+++ b/lib/devise/hooks/rememberable.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
+# This hook runs when a user logs in, if they set the `remember_me` param (eg. from a checkbox in the UI).
 Warden::Manager.after_set_user except: :fetch do |record, warden, options|
   scope = options[:scope]
   if record.respond_to?(:remember_me) && options[:store] != false &&
      record.remember_me && warden.authenticated?(scope)
+
+    Devise::Hooks::Proxy.new(warden).remember_me(record)
+  end
+end
+
+# This hook runs when we retrieve a user from the session. If the user's remember session should be extended
+# we do it here.
+Warden::Manager.after_set_user only: :fetch do |record, warden, options|
+  if record.respond_to?(:extend_remember_me?) && record.extend_remember_me? &&
+      options[:store] != false && warden.authenticated?(options[:scope])
+
     Devise::Hooks::Proxy.new(warden).remember_me(record)
   end
 end

--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -70,6 +70,10 @@ module Devise
         self.class.extend_remember_period
       end
 
+      def extend_remember_me?
+        !!self.class.extend_remember_period
+      end
+
       def rememberable_value
         if respond_to?(:remember_token)
           remember_token

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -169,7 +169,12 @@ Devise.setup do |config|
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
 
-  # If true, extends the user's remember period when remembered via cookie.
+  # If true, extends the user's remember period every time the user makes a request.
+  # As long as the user accesses the site once every `config.remember_for`, they can
+  # stay logged in forever.
+  # If false, how long the user will be remembered for is set on initial login,
+  # and only when the user starts a new session. So users will need to log in
+  # again every `config.remember_for`.
   # config.extend_remember_period = false
 
   # Options to be passed to the created cookie. For instance, you can set


### PR DESCRIPTION
This PR adds better tests for `extend_remember_period` and tries to better document what the feature is supposed to do. Currently it's not very well specified, and I'm not sure it's behaving as expected.

I found https://gitlab.com/gitlab-org/gitlab/-/merge_requests/32730 and https://github.com/heartcombo/devise/issues/3950#issuecomment-217326227 which both describe how the feature should work. To summarise:

- if you log in to the application regularly, `extend_remember_period` will keep your session alive
- if you *don't* log into the application for a while (longer than `config.remember_for`) you'll get logged out

In reality, it looks like what happens is:

- if you log in to the application regularly, your session will stay alive for as long as `config.remember_for`
- if you *don't* log into the application for a while (longer than `config.remember_for`) you'll stay logged in, as long as your warden session remains intact

So this means for example if you keep your browser open for longer than `config.remember_for`, your rememberable cookie will expire, but you'll still be logged in.

Currently how `extend_remember_period` works is that it only extends the session when [`Stratgies::Rememberable#authenticate`](https://github.com/heartcombo/devise/blob/master/lib/devise/strategies/rememberable.rb#L30) gets called. This gets called when the user logs in and a strategy is used. But if there's already a user logged in and recognised by warden, then warden [short circuits the strategies](https://github.com/wardencommunity/warden/blob/master/lib/warden/proxy.rb#L334).

So the first thing this PR change is to add a hook so that `extend_remember_period` now works on every request.

The next bug is that if once `config.remember_for` is up, the user is not currently forgotten.