### PR TITLE
Remove `ActiveSupport::Dependencies.reference`

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -318,7 +318,6 @@ module Devise
   end
 
   def self.ref(arg)
-    ActiveSupport::Dependencies.reference(arg)
     Getter.new(arg)
   end
 


### PR DESCRIPTION
This was deleted from Rails: https://github.com/rails/rails/commit/14d4edd7c3b06e82e1fcef54fa0b4453315c35fd, which means Devise currently crashes when run against Rails master.

As far as I can tell, it was meant to add a performance boost at some point in the past but doesn't seem to do anything useful these days.

cc @fxn