### PR TITLE
Trackable: save with touch: false

### DIFF
--- a/lib/devise/models/trackable.rb
+++ b/lib/devise/models/trackable.rb
@@ -37,7 +37,7 @@ module Devise
         return if new_record?
 
         update_tracked_fields(request)
-        save(validate: false)
+        save(validate: false, touch: false)
       end
 
       protected


### PR DESCRIPTION
With this, the `updated_at` timestamp won't be updated. We already have a tracking timestamp in `current_sign_in_at`, it doesn't make sense to also update `updated_at`.

See https://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-save