### PR TITLE
Adding WAI-ARIA attribute for error alert

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation">
+  <div id="error_explanation" role="alert" aria-live="assertive">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,


### PR DESCRIPTION
Adding attributes to the alert for better accessibility.
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role