### PR TITLE
Mirror rails default_sender logic

### DIFF
--- a/lib/devise/mailers/helpers.rb
+++ b/lib/devise/mailers/helpers.rb
@@ -53,7 +53,13 @@ module Devise
       def mailer_sender(mapping, sender = :from)
         default_sender = default_params[sender]
         if default_sender.present?
-          default_sender.respond_to?(:to_proc) ? instance_eval(&default_sender) : default_sender
+          return default_sender unless default_sender.is_a?(Proc)
+
+          if default_sender.arity == 1
+            instance_exec(self, &default_sender)
+          else
+            instance_exec(&default_sender)
+          end
         elsif Devise.mailer_sender.is_a?(Proc)
           Devise.mailer_sender.call(mapping.name)
         else


### PR DESCRIPTION
Update `default_sender` logic to mirror the [Rails `compute_default` method.](https://github.com/rails/rails/blob/9e66e5d027f32b2dc3b695471e9b99f214af3f0f/actionmailer/lib/action_mailer/base.rb#L913-L921) 

The existing code uses `instance_eval` which always passes `self` in as the first argument. The examples in the Rails guides and API docs use lambdas with no arguments. With the existing Devise code this raises an `ArgumentError` exception since lambda expects no arguments and one is passed.