### PR TITLE
Redirect if reset password token is expired

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -66,6 +66,15 @@ class Devise::PasswordsController < DeviseController
       if params[:reset_password_token].blank?
         set_flash_message(:alert, :no_token)
         redirect_to new_session_path(resource_name)
+      else
+        resource = resource_class.with_reset_password_token(params[:reset_password_token])
+        if resource.nil?
+          set_flash_message(:alert, :invalid_token)
+          redirect_to new_password_path(resource_name)
+        elsif !resource.reset_password_period_valid?
+          set_flash_message(:alert, :expired_token)
+          redirect_to new_password_path(resource_name)
+        end
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,8 @@ en:
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      invalid_token: "This password recovery link is invalid, please request a new one."
+      expired_token: "This password recovery link has expired, please request a new one."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -19,6 +19,26 @@ class PasswordsControllerTest < Devise::ControllerTestCase
     }
   end
 
+  test '#edit redirect if reset_password_token is missing' do
+    get :edit
+    assert_equal "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.", flash[:alert]
+    assert_redirected_to "http://test.host/users/sign_in"
+  end
+
+  test '#edit redirect if reset_password_token is invalid' do
+    get :edit, params: { reset_password_token: 'abcdef' }
+    assert_equal "This password recovery link is invalid, please request a new one.", flash[:alert]
+    assert_redirected_to "http://test.host/users/password/new"
+  end
+
+  test '#edit redirect if reset_password_token has expired' do
+    @user.reset_password_sent_at = @user.class.reset_password_within - 1.second
+    @user.save
+    get :edit, params: { reset_password_token: @raw }
+    assert_equal "This password recovery link has expired, please request a new one.", flash[:alert]
+    assert_redirected_to "http://test.host/users/password/new"
+  end
+
   test 'redirect to after_sign_in_path_for if after_resetting_password_path_for is not overridden' do
     put_update_with_params
     assert_redirected_to "http://test.host/"

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -152,17 +152,6 @@ class PasswordTest < Devise::IntegrationTest
     assert_redirected_to "/users/sign_in"
   end
 
-  test 'not authenticated user with invalid reset password token should not be able to change their password' do
-    user = create_user
-    reset_password reset_password_token: 'invalid_reset_password'
-
-    assert_response :success
-    assert_current_url '/users/password'
-    assert_have_selector '#error_explanation'
-    assert_contain %r{Reset password token(.*)invalid}
-    refute user.reload.valid_password?('987654321')
-  end
-
   test 'not authenticated user with valid reset password token but invalid password should not be able to change their password' do
     user = create_user
     request_forgot_password


### PR DESCRIPTION
If the user loads the password reset page with an expired or invalid password token, there is no point in showing the password+password_confirmation fields. The user would most likely want to request a new token, so redirect to the page for requesting a new token.