### PR TITLE
Deprecated ActiveSupport::Dependencies.constantize fix

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -313,7 +313,7 @@ module Devise
     end
 
     def get
-      ActiveSupport::Dependencies.constantize(@name)
+      @name.constantize
     end
   end
 


### PR DESCRIPTION
ActiveSupport::Dependencies.constantize(model_name) [was deprecated](https://github.com/rails/rails/pull/43058) in rails/main in favor of model_name.constantize