### PR TITLE
Use notice instead of alert for 'already_authenticated' flash message

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -112,7 +112,7 @@ MESSAGE
     end
 
     if authenticated && resource = warden.user(resource_name)
-      set_flash_message(:alert, 'already_authenticated', scope: 'devise.failure')
+      set_flash_message(:notice, 'already_authenticated', scope: 'devise.failure')
       redirect_to after_sign_in_path_for(resource)
     end
   end

--- a/test/controllers/internal_helpers_test.rb
+++ b/test/controllers/internal_helpers_test.rb
@@ -75,7 +75,7 @@ class HelpersTest < Devise::ControllerTestCase
     @mock_warden.expects(:user).with(:user).returns(User.new)
     @controller.expects(:redirect_to).with(root_path)
     @controller.send :require_no_authentication
-    assert flash[:alert] == I18n.t("devise.failure.already_authenticated")
+    assert flash[:notice] == I18n.t("devise.failure.already_authenticated")
   end
 
   test 'signed in resource returns signed in resource for current scope' do

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -321,14 +321,14 @@ class AuthenticationRedirectTest < Devise::IntegrationTest
   test 'require_no_authentication should set the already_authenticated flash message' do
     sign_in_as_user
     visit new_user_session_path
-    assert_equal I18n.t("devise.failure.already_authenticated"), flash[:alert]
+    assert_equal I18n.t("devise.failure.already_authenticated"), flash[:notice]
   end
 
   test 'require_no_authentication should set the already_authenticated flash message as admin' do
     store_translations :en, devise: { failure: { admin: { already_authenticated: 'You are already signed in as admin.' } } } do
       sign_in_as_admin
       visit new_admin_session_path
-      assert_equal "You are already signed in as admin.", flash[:alert]
+      assert_equal "You are already signed in as admin.", flash[:notice]
     end
   end
 end


### PR DESCRIPTION
In most Rails apps, `flash[:alert]` messages are represented as error messages. It seems a little awkward and inappropriate to display the `already_authenticated` message as an error message. It would seem to make more sense to display it as a success message. 

This PR sets `already_authenticated` as a `flash[:notice]` instead of `flash[:alert]`. 
