### PR TITLE
Fix that when a user signs in after the previous session timed out, the previous session was erroneously extended even without valid login credentials provided

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Devise::SessionsController < DeviseController
-  prepend_before_action :require_no_authentication, only: [:new]
+  prepend_before_action :require_no_authentication, only: [:new, :create]
   prepend_before_action :allow_params_authentication!, only: :create
   prepend_before_action :verify_signed_out_user, only: :destroy
   prepend_before_action(only: [:create, :destroy]) { request.env["devise.timeout_dont_throw"] = true }

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 class Devise::SessionsController < DeviseController
-  prepend_before_action :require_no_authentication, only: [:new, :create]
+  prepend_before_action :require_no_authentication, only: [:new]
   prepend_before_action :allow_params_authentication!, only: :create
   prepend_before_action :verify_signed_out_user, only: :destroy
-  prepend_before_action(only: [:create, :destroy]) { request.env["devise.skip_timeout"] = true }
+  prepend_before_action(only: [:create, :destroy]) { request.env["devise.timeout_dont_throw"] = true }
 
   # GET /resource/sign_in
   def new

--- a/lib/devise/controllers/sign_in_out.rb
+++ b/lib/devise/controllers/sign_in_out.rb
@@ -77,13 +77,14 @@ module Devise
       #   sign_out :user     # sign_out(scope)
       #   sign_out @user     # sign_out(resource)
       #
-      def sign_out(resource_or_scope = nil)
-        return sign_out_all_scopes unless resource_or_scope
+      def sign_out(resource_or_scope = nil, lock: true)
+        return sign_out_all_scopes(lock) unless resource_or_scope
         scope = Devise::Mapping.find_scope!(resource_or_scope)
         user = warden.user(scope: scope, run_callbacks: false) # If there is no user
 
         warden.logout(scope)
         warden.clear_strategies_cache!(scope: scope)
+        warden.lock! if lock
         instance_variable_set(:"@current_#{scope}", nil)
 
         !!user

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -117,7 +117,7 @@ class SessionTimeoutTest < Devise::IntegrationTest
     user = sign_in_as_user
     get expire_user_path(user)
 
-    post "/users/sign_in", params: { email: user.email, password: "123456" }
+    post "/users/sign_in", params: { user: { email: user.email, password: "12345678" } }
 
     assert_response :redirect
     follow_redirect!

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -124,6 +124,15 @@ class SessionTimeoutTest < Devise::IntegrationTest
     assert_contain 'You are signed in'
   end
 
+  test 'user should not sign in automatically when calling signing in after timed out' do
+    user = sign_in_as_user
+    get expire_user_path(user)
+
+    post "/users/sign_in", params: { user: { email: user.email, password: "WRONG PASSWORD" } }
+
+    assert_contain 'Invalid Email or password'
+  end
+
   test 'user configured timeout limit' do
     swap Devise, timeout_in: 8.minutes do
       user = sign_in_as_user


### PR DESCRIPTION
# Background

The `after_set_user` hook of `:timeoutable` reads the variable `env['devise.skip_timeout']` in order to prevent from that the user tries to sign in after timed out but interrupted by the timeout `after_set_user` hook.  This causes problem because when the user is signing in after timed out, Devise fetches the user from the session, ignoring the timeout check (by `env['devise.skip_timeout']`), which extends the previous login session without even run any strategies.

# Fix

To fix this, the timeout check should not be skipped, and it should not interrupt the current signing in request either. To achieve this, I renamed `env['devise.skip_timeout']` to `env["devise.timeout_dont_throw"]`, to indicate the new behavior.

- This is set for `SessionsController#create` and `SessionsController#destroy` as before
- When it's set to true
  - The timeout check is still performed
  - It does not throw `:warden` when the check fails
  - It does not lock `Warden::Proxy`. If which is locked, no strategies will run in this request.