### PR TITLE
Fix comment in some modules

### DIFF
--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -10,7 +10,7 @@ module Devise
     #
     # == Options
     #
-    # Authenticatable adds the following options to devise_for:
+    # Authenticatable adds the following options to devise method in your model:
     #
     #   * +authentication_keys+: parameters used for authentication. By default [:email].
     #

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -13,7 +13,7 @@ module Devise
     #
     # == Options
     #
-    # DatabaseAuthenticatable adds the following options to devise_for:
+    # DatabaseAuthenticatable adds the following options to devise method in your model:
     #
     #   * +pepper+: a random string used to provide a more secure hash. Use
     #     `rails secret` to generate new keys.

--- a/lib/devise/models/omniauthable.rb
+++ b/lib/devise/models/omniauthable.rb
@@ -8,11 +8,11 @@ module Devise
     #
     # == Options
     #
-    # Oauthable adds the following options to devise_for:
+    # Oauthable adds the following options to devise method in your model:
     #
     #   * +omniauth_providers+: Which providers are available to this model. It expects an array:
     #
-    #       devise_for :database_authenticatable, :omniauthable, omniauth_providers: [:twitter]
+    #       devise :database_authenticatable, :omniauthable, omniauth_providers: [:twitter]
     #
     module Omniauthable
       extend ActiveSupport::Concern

--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -11,7 +11,7 @@ module Devise
     #
     # == Options
     #
-    # Timeoutable adds the following options to devise_for:
+    # Timeoutable adds the following options to devise method in your model:
     #
     #   * +timeout_in+: the interval to timeout the user session without activity.
     #

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -9,7 +9,7 @@ module Devise
     #
     # == Options
     #
-    # Validatable adds the following options to devise_for:
+    # Validatable adds the following options to devise method in your model:
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
     #   * +password_length+: a range expressing password length. Defaults to 6..128.


### PR DESCRIPTION
I think some comments in specific modules are incorrect.
In some modules, It says that the option is added to `devise_for`, but I think it is actually added to the `devise` method in the model.
In the [README](https://github.com/heartcombo/devise/blob/master/README.md#configuring-models) and  [test/rails_app/lib/shared_user.rb](https://github.com/heartcombo/devise/blob/master/test/rails_app/lib/shared_user.rb), it is specified as options for the `devise` method.

