### PR TITLE
Return 303 on redirect for Turbo

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -77,7 +77,7 @@ class Devise::SessionsController < DeviseController
     # support returning empty response on GET request
     respond_to do |format|
       format.all { head :no_content }
-      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
+      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name), status: 303 }
     end
   end
 end


### PR DESCRIPTION
Turbo uses the `DELETE` verb directly so when redirecting with a 302 it retains that verb and the routing fails. This change will use status 303 which will force a change to `GET` which will allow proper redirecting after sign out.

More information can be found in the following issues:
https://github.com/hotwired/turbo/issues/84
https://github.com/hotwired/turbo-rails/issues/259
https://github.com/rails/rails/pull/43430