### PR TITLE
Fix bugs in `extend_remember_period`

### DIFF
--- a/lib/devise/hooks/rememberable.rb
+++ b/lib/devise/hooks/rememberable.rb
@@ -1,9 +1,21 @@
 # frozen_string_literal: true
 
+# This hook runs when a user logs in, if they set the `remember_me` param (eg. from a checkbox in the UI).
 Warden::Manager.after_set_user except: :fetch do |record, warden, options|
   scope = options[:scope]
   if record.respond_to?(:remember_me) && options[:store] != false &&
      record.remember_me && warden.authenticated?(scope)
+
+    Devise::Hooks::Proxy.new(warden).remember_me(record)
+  end
+end
+
+# This hook runs when we retrieve a user from the session. If the user's remember session should be extended
+# we do it here.
+Warden::Manager.after_set_user only: :fetch do |record, warden, options|
+  if record.respond_to?(:extend_remember_me?) && record.extend_remember_me? &&
+      options[:store] != false && warden.authenticated?(options[:scope])
+
     Devise::Hooks::Proxy.new(warden).remember_me(record)
   end
 end

--- a/lib/devise/hooks/rememberable.rb
+++ b/lib/devise/hooks/rememberable.rb
@@ -16,6 +16,7 @@ Warden::Manager.after_set_user only: :fetch do |record, warden, options|
   if record.respond_to?(:extend_remember_me?) && record.extend_remember_me? &&
       options[:store] != false && warden.authenticated?(options[:scope])
 
-    Devise::Hooks::Proxy.new(warden).remember_me(record)
+    proxy = Devise::Hooks::Proxy.new(warden)
+    proxy.remember_me(record) if proxy.remember_me_is_active?(record)
   end
 end

--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -70,6 +70,10 @@ module Devise
         self.class.extend_remember_period
       end
 
+      def extend_remember_me?
+        !!self.class.extend_remember_period
+      end
+
       def rememberable_value
         if respond_to?(:remember_token)
           remember_token

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -169,7 +169,12 @@ Devise.setup do |config|
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
 
-  # If true, extends the user's remember period when remembered via cookie.
+  # If true, extends the user's remember period every time the user makes a request.
+  # As long as the user accesses the site once every `config.remember_for`, they can
+  # stay logged in forever.
+  # If false, how long the user will be remembered for is set on initial login,
+  # and only when the user starts a new session. So users will need to log in
+  # again every `config.remember_for`.
   # config.extend_remember_period = false
 
   # Options to be passed to the created cookie. For instance, you can set

--- a/test/integration/rememberable_test.rb
+++ b/test/integration/rememberable_test.rb
@@ -143,7 +143,7 @@ class RememberMeTest < Devise::IntegrationTest
   end
 
   test 'extends remember period on every authenticated request when extend remember period config is true' do
-    swap Devise, extend_remember_period: true, remember_for: 1.year, timeout_in: nil do
+    swap Devise, extend_remember_period: true, remember_for: 1.year, timeout_in: 6.hours do
       user = create_user_and_remember
 
       get root_path
@@ -182,7 +182,7 @@ class RememberMeTest < Devise::IntegrationTest
   end
 
   test 'does not extend remember period when extend period config is false' do
-    swap Devise, extend_remember_period: false, remember_for: 1.year, timeout_in: nil do
+    swap Devise, extend_remember_period: false, remember_for: 1.year, timeout_in: 6.hours do
       user = create_user_and_remember
 
       get root_path


### PR DESCRIPTION
This is a modified version of https://github.com/heartcombo/devise/pull/5351 that fixes the remaining issues:
* Only extend remember_me if remember_me is currently active
* Set a timeout for extend_remember_period tests, otherwise the session doesn't expire so the user will never be logged out