### PR TITLE
Improved failure_message to interpret OAuth2::Error

### DIFF
--- a/app/controllers/devise/omniauth_callbacks_controller.rb
+++ b/app/controllers/devise/omniauth_callbacks_controller.rb
@@ -21,7 +21,11 @@ class Devise::OmniauthCallbacksController < DeviseController
   def failure_message
     exception = request.respond_to?(:get_header) ? request.get_header("omniauth.error") : request.env["omniauth.error"]
     error   = exception.error_reason if exception.respond_to?(:error_reason)
+    error ||= exception.description  if exception.respond_to?(:description)
+    return error.to_s if error # Description and Error_reason are normal text    
+    
     error ||= exception.error        if exception.respond_to?(:error)
+    error ||= exception.code         if exception.respond_to?(:code)
     error ||= (request.respond_to?(:get_header) ? request.get_header("omniauth.error.type") : request.env["omniauth.error.type"]).to_s
     error.to_s.humanize if error
   end


### PR DESCRIPTION
OAuth2::Error Exceptions do not have `error_reason` and `error` as the Omniauth::CallbackError, but rather use the fields `description` and `code`. 

This is particularly useful if the error is returned server-side and handled by OAuth2.

See: `callback_phase` can return `OAuth2::Error` or `CallbackError`
https://github.com/omniauth/omniauth-oauth2/blob/561ddcef4d7791bc46ff1d718de5db13894d8033/lib/omniauth/strategies/oauth2.rb#L84

See: Definition of `CallbackError`
https://github.com/omniauth/omniauth-oauth2/blob/561ddcef4d7791bc46ff1d718de5db13894d8033/lib/omniauth/strategies/oauth2.rb#L149

See: Definition of `OAuth2::Error`
https://github.com/oauth-xx/oauth2/blob/1940e9ad6f395b2fb80f09e4140d17fe0344325a/lib/oauth2/error.rb#L4