### PR TITLE
Delegate sign_in_after_reset_password to resource class

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -36,7 +36,7 @@ class Devise::PasswordsController < DeviseController
 
     if resource.errors.empty?
       resource.unlock_access! if unlockable?(resource)
-      if Devise.sign_in_after_reset_password
+      if resource_class.sign_in_after_reset_password
         flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
         set_flash_message!(:notice, flash_message)
         resource.after_database_authentication
@@ -53,7 +53,7 @@ class Devise::PasswordsController < DeviseController
 
   protected
     def after_resetting_password_path_for(resource)
-      Devise.sign_in_after_reset_password ? after_sign_in_path_for(resource) : new_session_path(resource_name)
+      resource_class.sign_in_after_reset_password ? after_sign_in_path_for(resource) : new_session_path(resource_name)
     end
 
     # The path used after sending reset password instructions

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -222,6 +222,31 @@ class PasswordTest < Devise::IntegrationTest
     end
   end
 
+  test 'does not sign in user automatically after changing its password if resource_class.sign_in_after_reset_password is false' do
+    swap User, sign_in_after_reset_password: false do
+      create_user
+      request_forgot_password
+      reset_password
+
+      assert_contain 'Your password has been changed successfully'
+      assert_not_contain 'You are now signed in.'
+      assert_equal new_user_session_path, @request.path
+      assert !warden.authenticated?(:user)
+    end
+  end
+
+  test 'sign in user automatically after changing its password if resource_class.sign_in_after_reset_password is true' do
+    swap Devise, sign_in_after_reset_password: false do
+      swap User, sign_in_after_reset_password: true do
+        create_user
+        request_forgot_password
+        reset_password
+
+        assert warden.authenticated?(:user)
+      end
+    end
+  end
+
   test 'does not sign in user automatically after changing its password if it\'s locked and unlock strategy is :none or :time' do
     [:none, :time].each do |strategy|
       swap Devise, unlock_strategy: strategy do


### PR DESCRIPTION
Allows resource class scopes to overrides the global configuration for sign in after reset password behaviour.