### PR TITLE
Add :turbo_stream as a default navigational format

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -217,7 +217,7 @@ module Devise
 
   # Which formats should be treated as navigational.
   mattr_accessor :navigational_formats
-  @@navigational_formats = ["*/*", :html]
+  @@navigational_formats = ["*/*", :html, :turbo_stream]
 
   # When set to true, signing out a user signs out all other scopes.
   mattr_accessor :sign_out_all_scopes


### PR DESCRIPTION
Fixes #5439

Rails 7 returns `:turbo_stream` as a request format out-of-the-box. I'm on the fence whether this is the right change to make or if it should be left up to the user to add it as a configuration in their initializer. I opted to open the PR since it is a format that a vanilla Rails 7 app will use, which means vanilla Devise will break with vanilla Rails without this change.

Feel free to close if it's best left as-is.