### PR TITLE
Better handle redirection on sign out

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -77,7 +77,7 @@ class Devise::SessionsController < DeviseController
     # support returning empty response on GET request
     respond_to do |format|
       format.all { head :no_content }
-      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
+      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name), status: :see_other }
     end
   end
 end


### PR DESCRIPTION
Issue: When a user signs out from a protected page (aka a page only accessible when signed in), Rails 7 (tested on 7.0.1) does not properly redirect to the root_path or another page specified by the user in the `after_sign_out_path_for` method as it uses a 302 status.

Changing to a status 303 enable proper redirection to the root page (or any other page assigned using `after_sign_out_path_for`).