### PR TITLE
Moving generator method to private

### DIFF
--- a/lib/generators/active_record/devise_generator.rb
+++ b/lib/generators/active_record/devise_generator.rb
@@ -40,6 +40,8 @@ module ActiveRecord
         inject_into_class(model_path, class_path.last, content) if model_exists?
       end
 
+      private
+
       def migration_data
 <<RUBY
       ## Database authenticatable


### PR DESCRIPTION
Hi.

I noticed that there is refactoring point  in `lib/generators/active_record/devise_generator.rb`, and so I created PR.

All public methods in `devise_generator.rb`  is called by executing `rails g active_record:devise`.
But I think that those methods except for `copy_devise_migration`, `generate_model` and `inject_devise_content`  are not needed to call  because of not commands which generate files.
 
I think it is better that those methods are defined as private.

After changing code, I checked generator command and minitest, then it seems no problem as before.

exec `rails g active_record:devise hoge`

```
 rails g active_record:devise hoge
      create  db/migrate/20220115061612_devise_create_hoges.rb
      create  app/models/hoge.rb
      invoke  rspec
      create    spec/models/hoge_spec.rb
      insert  app/models/hoge.rb
```

exec  `bin/test test/generators/active_record_generator_test.rb  `

```
 bin/test test/generators/active_record_generator_test.rb  
==> Devise.orm = :active_record
Run options: --seed 40973

# Running:

..........

Finished in 0.071228s, 140.3942 runs/s, 687.9317 assertions/s.
10 runs, 49 assertions, 0 failures, 0 errors, 0 skips
```

Feel free to close if it's best left as-is.