### PR TITLE
api_only? option for devise_for

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -175,6 +175,11 @@ module ActionDispatch::Routing
     #
     #  * router_name: allows application level router name to be overwritten for the current scope
     #
+    #  * api_only?: when true removes unnecessary routes for api_only apllications,
+    #    uses rails api_only config by default.
+    #
+    #     devise_for :users, api_only?: true
+    #
     # ==== Scoping
     #
     # Following Rails 3 routes DSL, you can nest devise_for calls inside a scope:

--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -236,6 +236,7 @@ module ActionDispatch::Routing
       options[:defaults]      = (@scope[:defaults] || {}).merge(options[:defaults] || {})
       options[:options]       = @scope[:options] || {}
       options[:options][:format] = false if options[:format] == false
+      options[:api_only?] = api_only? if options[:api_only?].blank?
 
       resources.map!(&:to_sym)
 
@@ -265,7 +266,7 @@ module ActionDispatch::Routing
 
         devise_scope mapping.name do
           with_devise_exclusive_scope mapping.fullpath, mapping.name, options do
-            routes.each { |mod| send("devise_#{mod}", mapping, mapping.controllers) }
+            routes.each { |mod| send("devise_#{mod}", mapping, mapping.controllers, options[:api_only?]) }
           end
         end
       end
@@ -374,32 +375,35 @@ module ActionDispatch::Routing
 
     protected
 
-      def devise_session(mapping, controllers) #:nodoc:
+      def devise_session(mapping, controllers, api_only) #:nodoc:
         resource :session, only: [], controller: controllers[:sessions], path: "" do
-          get   :new,     path: mapping.path_names[:sign_in],  as: "new"
+          get   :new,     path: mapping.path_names[:sign_in],  as: "new" unless api_only
           post  :create,  path: mapping.path_names[:sign_in]
           match :destroy, path: mapping.path_names[:sign_out], as: "destroy", via: mapping.sign_out_via
         end
       end
 
-      def devise_password(mapping, controllers) #:nodoc:
-        resource :password, only: [:new, :create, :edit, :update],
+      def devise_password(mapping, controllers, api_only) #:nodoc:
+        actions = api_only ? [:create, :update] : [:new, :create, :edit, :update]
+        resource :password, only: actions,
           path: mapping.path_names[:password], controller: controllers[:passwords]
       end
 
-      def devise_confirmation(mapping, controllers) #:nodoc:
-        resource :confirmation, only: [:new, :create, :show],
+      def devise_confirmation(mapping, controllers, api_only) #:nodoc:
+        actions = api_only ? [:create, :show] : [:new, :create, :show]
+        resource :confirmation, only: actions,
           path: mapping.path_names[:confirmation], controller: controllers[:confirmations]
       end
 
-      def devise_unlock(mapping, controllers) #:nodoc:
+      def devise_unlock(mapping, controllers, api_only) #:nodoc:
+        actions = api_only ? [:create, :show] :  [:new, :create, :show]
         if mapping.to.unlock_strategy_enabled?(:email)
-          resource :unlock, only: [:new, :create, :show],
+          resource :unlock, only: actions,
             path: mapping.path_names[:unlock], controller: controllers[:unlocks]
         end
       end
 
-      def devise_registration(mapping, controllers) #:nodoc:
+      def devise_registration(mapping, controllers, api_only) #:nodoc:
         path_names = {
           new: mapping.path_names[:sign_up],
           edit: mapping.path_names[:edit],
@@ -407,7 +411,7 @@ module ActionDispatch::Routing
         }
 
         options = {
-          only: [:new, :create, :edit, :update, :destroy],
+          only: api_only ? [:create, :update, :destroy] : [:new, :create, :edit, :update, :destroy],
           path: mapping.path_names[:registration],
           path_names: path_names,
           controller: controllers[:registrations]


### PR DESCRIPTION
This PR solves the problem with unused routes for api_only projects using devise (Issue #5242).
Its adds a new option for devise_for called api_only and when is true, removes new and edit actions from routes.

I have made this repo (https://github.com/PedroAugustoRamalhoDuarte/devise-api-only) to test this feature:

When we run `rails routes` with `devise_for :users`:
```
                                  Prefix Verb   URI Pattern                                                                                       Controller#Action
                        new_user_session GET    /users/sign_in(.:format)                                                                          devise/sessions#new
                            user_session POST   /users/sign_in(.:format)                                                                          devise/sessions#create
                    destroy_user_session DELETE /users/sign_out(.:format)                                                                         devise/sessions#destroy
                       new_user_password GET    /users/password/new(.:format)                                                                     devise/passwords#new
                      edit_user_password GET    /users/password/edit(.:format)                                                                    devise/passwords#edit
                           user_password PATCH  /users/password(.:format)                                                                         devise/passwords#update
                                         PUT    /users/password(.:format)                                                                         devise/passwords#update
                                         POST   /users/password(.:format)                                                                         devise/passwords#create
                cancel_user_registration GET    /users/cancel(.:format)                                                                           devise/registrations#cancel
                   new_user_registration GET    /users/sign_up(.:format)                                                                          devise/registrations#new
                  edit_user_registration GET    /users/edit(.:format)                                                                             devise/registrations#edit
                       user_registration PATCH  /users(.:format)                                                                                  devise/registrations#update
                                         PUT    /users(.:format)                                                                                  devise/registrations#update
                                         DELETE /users(.:format)                                                                                  devise/registrations#destroy
                                         POST   /users(.:format)                                                                                  devise/registrations#create
```

with `devise_for :users, api_only?: true`:
```
                                  Prefix Verb   URI Pattern                                                                                       Controller#Action
                            user_session POST   /users/sign_in(.:format)                                                                          devise/sessions#create
                    destroy_user_session DELETE /users/sign_out(.:format)                                                                         devise/sessions#destroy
                           user_password PATCH  /users/password(.:format)                                                                         devise/passwords#update
                                         PUT    /users/password(.:format)                                                                         devise/passwords#update
                                         POST   /users/password(.:format)                                                                         devise/passwords#create
                cancel_user_registration GET    /users/cancel(.:format)                                                                           devise/registrations#cancel
                       user_registration PATCH  /users(.:format)                                                                                  devise/registrations#update
                                         PUT    /users(.:format)                                                                                  devise/registrations#update
                                         DELETE /users(.:format)                                                                                  devise/registrations#destroy
                                         POST   /users(.:format)                                                                                  devise/registrations#create
```

I would like to write some specs too, does anyone have any tips?