### PR TITLE
Allows redirections to other/external hosts after logout, for Rails 7

### DIFF
--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -77,7 +77,11 @@ class Devise::SessionsController < DeviseController
     # support returning empty response on GET request
     respond_to do |format|
       format.all { head :no_content }
-      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
+      format.any(*navigational_formats) { redirect_to_after_sign_out_path }
     end
+  end
+
+  def redirect_to_after_sign_out_path
+    redirect_to after_sign_out_path_for(resource_name), allow_other_host: true
   end
 end


### PR DESCRIPTION
## Context

When using different authentication strategies, [devise_saml_autheticatable](https://github.com/apokalipto/devise_saml_authenticatable) in my case, it's common to redirect the user to a different/external host after logout. 

Rails 7 requires to explicitly pass `allow_other_host: true` to `redirect_to` to allow such redirections. Otherwise, an ugly exception is raised.

* Devise `4.8.1`
* Rails `7.01`

## Expected behaviour.

When using devise with Rails 7 and setting the `after_sign_out_path_for` to an external host, the user is sucessfully redirected.

## Current behaviour.

When using devise with Rails 7 and setting the `after_sign_out_path_for` to an external host, a `ActionController::Redirecting::UnsafeRedirectError` is raised.

