### PR TITLE
Fix bug with sign_out_all_scopes trying to edit resource after it has already been destroyed

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -63,8 +63,8 @@ class Devise::RegistrationsController < DeviseController
 
   # DELETE /resource
   def destroy
-    resource.destroy
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
+    resource.destroy
     set_flash_message! :notice, :destroyed
     yield resource if block_given?
     respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }


### PR DESCRIPTION
When destroying a resource and resource is rememberable, `Devise.sign_out_all_scopes` attempts to edit the resource after resource has already been destroyed.  The reason is because `lib/devise/models/rememberable.rb:60: forget_me!` sets the `remember_token` and `remember_created_at` fields and then calls `save(validate: false)`.

The solution is pretty straightforward. We should first call `Devise.sign_out_all_scopes` and then `resource.destroy`.