### PR TITLE
Monkeypatch webrat for Nokogiri compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem "rails-controller-testing", github: "rails/rails-controller-testing"
 gem "responders", "~> 3.0"
 
 group :test do
-  gem "nokogiri", "< 1.13"
   gem "omniauth-facebook"
   gem "omniauth-openid"
   gem "rexml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     mocha (1.13.0)
     multi_json (1.15.0)
@@ -129,8 +129,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     oauth2 (1.4.9)
       faraday (>= 0.17.3, < 3.0)
@@ -222,7 +222,6 @@ PLATFORMS
 DEPENDENCIES
   devise!
   mocha (~> 1.1)
-  nokogiri (< 1.13)
   omniauth
   omniauth-facebook
   omniauth-oauth2

--- a/gemfiles/Gemfile-rails-5-0
+++ b/gemfiles/Gemfile-rails-5-0
@@ -14,7 +14,6 @@ gem "rails-controller-testing"
 gem "responders", "~> 2.1"
 
 group :test do
-  gem "nokogiri", "< 1.13"
   gem "omniauth-facebook"
   gem "omniauth-openid"
   gem "timecop"

--- a/gemfiles/Gemfile-rails-5-1
+++ b/gemfiles/Gemfile-rails-5-1
@@ -12,7 +12,6 @@ gem "rails-controller-testing"
 gem "responders", "~> 2.1"
 
 group :test do
-  gem "nokogiri", "< 1.13"
   gem "omniauth-facebook"
   gem "omniauth-openid"
   gem "timecop"

--- a/gemfiles/Gemfile-rails-5-2
+++ b/gemfiles/Gemfile-rails-5-2
@@ -12,7 +12,6 @@ gem "rails-controller-testing"
 gem "responders", "~> 2.1"
 
 group :test do
-  gem "nokogiri", "< 1.13"
   gem "omniauth-facebook"
   gem "omniauth-openid"
   gem "timecop"

--- a/gemfiles/Gemfile-rails-6-0
+++ b/gemfiles/Gemfile-rails-6-0
@@ -12,7 +12,6 @@ gem "rails-controller-testing", github: "rails/rails-controller-testing"
 gem "responders", "~> 3.0"
 
 group :test do
-  gem "nokogiri", "< 1.13"
   gem "omniauth-facebook"
   gem "omniauth-openid"
   gem "rexml"

--- a/gemfiles/Gemfile-rails-6-1
+++ b/gemfiles/Gemfile-rails-6-1
@@ -20,7 +20,6 @@ if RUBY_VERSION >= "3.1"
 end
 
 group :test do
-  gem "nokogiri", "< 1.13"
   gem "omniauth-facebook"
   gem "omniauth-openid"
   gem "rexml"

--- a/gemfiles/Gemfile-rails-main
+++ b/gemfiles/Gemfile-rails-main
@@ -14,7 +14,6 @@ gem "rails-controller-testing", github: "rails/rails-controller-testing"
 gem "responders", "~> 3.0"
 
 group :test do
-  gem "nokogiri", "< 1.13"
   gem "omniauth-facebook"
   gem "omniauth-openid"
   gem "rexml"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,20 @@ I18n.load_path << File.expand_path("../support/locale/en.yml", __FILE__)
 require 'mocha/minitest'
 require 'timecop'
 require 'webrat'
+
+# Monkey patch for Nokogiri changes - https://github.com/sparklemotion/nokogiri/issues/2469
+module Webrat
+  module Matchers
+    class HaveSelector
+      def query
+          Nokogiri::CSS.parse(@expected.to_s).map do |ast|
+            ast.to_xpath("//", Nokogiri::CSS::XPathVisitor.new)
+          end.first
+      end
+    end
+  end
+end
+
 Webrat.configure do |config|
   config.mode = :rails
   config.open_error_files = false


### PR DESCRIPTION
This is an attempt to address the Webrat / Nokogiri compatibility issue discussed [here](https://github.com/sparklemotion/nokogiri/issues/2469).  It monkeypatches Webrat to explicitly add the old default arguments to the invocation of `to_xpath`.

This PR picked an unrelated failure in Rails main specs because of this [commit](https://github.com/rails/rails/commit/c2e756a944fd3ca2efa58bd285c0e75e0b4794ab), which removes the body content from a redirect response.  Devise has tests that check that body content, and those tests are now failing.  I would suggest we remove those specs, and I'm happy to put up a PR to do so.  Just let me know if such a PR is desired.

UPDATE: As the unrelated failure is now fixed in `main`, I've rebased this PR and it now exclusively addresses the Webrat issue.

cc: @carlosantoniodasilva, @flavorjones