### PR TITLE
Fixing Zeitwerk errors when running Devise without ActionMailer

### DIFF
--- a/app/mailers/devise/mailer.rb
+++ b/app/mailers/devise/mailer.rb
@@ -28,6 +28,8 @@ if defined?(ActionMailer)
     end
   end
 else
-  class Devise::Mailer
+  if Rails.autoloaders.zeitwerk_enabled?
+    class Devise::Mailer
+    end
   end
 end

--- a/app/mailers/devise/mailer.rb
+++ b/app/mailers/devise/mailer.rb
@@ -27,4 +27,7 @@ if defined?(ActionMailer)
       devise_mail(record, :password_change, opts)
     end
   end
+else
+  class DeviseMailer
+  end
 end

--- a/app/mailers/devise/mailer.rb
+++ b/app/mailers/devise/mailer.rb
@@ -28,6 +28,6 @@ if defined?(ActionMailer)
     end
   end
 else
-  class DeviseMailer
+  class Devise::Mailer
   end
 end


### PR DESCRIPTION
This fixes the longstanding issue #5140 where Zeitwerk throws errors around when using Devise without ActionMailer.

Overall behaviour shouldn't be effected. The new empty class is only used when the application would otherwise error our (ActionMailer not available and Zeitwerk enabled)