### PR TITLE
Disable turbo by default

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, data: { turbo: false } }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, data: { turbo: false } }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, data: { turbo: false } }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, data: { turbo: false } }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
@@ -38,6 +38,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo: false }, method: :delete %></p>
 
 <%= link_to "Back", :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Log in</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: false }) do |f| %>
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,6 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false } %><br />
   <% end %>
 <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,6 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false } %><br />
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post, data: { turbo: false } %><br />
   <% end %>
 <% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend unlock instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post, data: { turbo: false } }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/lib/generators/templates/README
+++ b/lib/generators/templates/README
@@ -16,7 +16,7 @@ Depending on your application's configuration some manual setup may be required:
      For example:
 
        root to: "home#index"
-
+     
      * Not required for API-only Applications *
 
   3. Ensure you have flash messages in app/views/layouts/application.html.erb.
@@ -30,19 +30,7 @@ Depending on your application's configuration some manual setup may be required:
   4. You can copy Devise views (for customization) to your app by running:
 
        rails g devise:views
-
+       
      * Not required *
-
-  5. Ensure you have rails-ujs installed:
-    If you use importmap-rails, you can run:
-
-       bin/importmap pin @rails/ujs
-
-    Then add in app/javascript/application.js:
-
-       import Rails from "@rails/ujs";
-       Rails.start();
-
-    * Required if you use the data-method attribute in your links *
 
 ===============================================================================

--- a/lib/generators/templates/README
+++ b/lib/generators/templates/README
@@ -16,7 +16,7 @@ Depending on your application's configuration some manual setup may be required:
      For example:
 
        root to: "home#index"
-     
+
      * Not required for API-only Applications *
 
   3. Ensure you have flash messages in app/views/layouts/application.html.erb.
@@ -30,7 +30,19 @@ Depending on your application's configuration some manual setup may be required:
   4. You can copy Devise views (for customization) to your app by running:
 
        rails g devise:views
-       
+
      * Not required *
+
+  5. Ensure you have rails-ujs installed:
+    If you use importmap-rails, you can run:
+
+       bin/importmap pin @rails/ujs
+
+    Then add in app/javascript/application.js:
+
+       import Rails from "@rails/ujs";
+       Rails.start();
+
+    * Required if you use the data-method attribute in your links *
 
 ===============================================================================

--- a/lib/generators/templates/simple_form_for/registrations/edit.html.erb
+++ b/lib/generators/templates/simple_form_for/registrations/edit.html.erb
@@ -30,6 +30,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo: false }, method: :delete %></p>
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo: false }, method: :delete %></p>
 
 <%= link_to "Back", :back %>

--- a/lib/generators/templates/simple_form_for/registrations/edit.html.erb
+++ b/lib/generators/templates/simple_form_for/registrations/edit.html.erb
@@ -30,6 +30,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo: false }, method: :delete %></p>
 
 <%= link_to "Back", :back %>


### PR DESCRIPTION
Until `devise` is compatible with `Turbo` out of the box, I suggest we disable it by default.

A lot of newcomers installing Rails and devise for the first time might become discouraged when they can't figure out why an essential feature such as authentication doesn't work without extensive efforts.