### PR TITLE
Change define_helpers parameters to String

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -354,7 +354,7 @@ module Devise
     mapping = Devise::Mapping.new(resource, options)
     @@mappings[mapping.name] = mapping
     @@default_scope ||= mapping.name
-    @@helpers.each { |h| h.define_helpers(mapping) }
+    @@helpers.each { |h| h.define_helpers(mapping.name) }
     mapping
   end
 

--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -110,7 +110,6 @@ module Devise
       #     before_action :authenticate_admin! # Tell devise to use :admin map
       #
       def self.define_helpers(mapping) #:nodoc:
-        mapping = mapping.name
 
         class_eval <<-METHODS, __FILE__, __LINE__ + 1
           def authenticate_#{mapping}!(opts = {})


### PR DESCRIPTION
The `define_helpers` method takes an instance of `Devise::Mapping` as an argument, which is a very large object. Within the method a local variable `mapping`,  which is set to the name instance variable of the mapping object. This variable is then used in the method to meta program helper methods like` user_signed_in?` etc.

It is unnecessary to pass an entire `Devise::Mapping ` to `define_helpers`. Instead I propose passing the @name of the mapping directly to `define_helpers`. The assignment of the `mapping` variable can now also be removed. This change simplifies code and speeds up the program by avoiding passing large objects to functions.