### PR TITLE
fix: add status codes to redirects and failure app

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -14,7 +14,7 @@ class Devise::ConfirmationsController < DeviseController
     if successfully_sent?(resource)
       respond_with({}, location: after_resending_confirmation_instructions_path_for(resource_name))
     else
-      respond_with(resource)
+      respond_with(resource, status: Devise.failure_status_code)
     end
   end
 

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -18,7 +18,7 @@ class Devise::PasswordsController < DeviseController
     if successfully_sent?(resource)
       respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
     else
-      respond_with(resource)
+      respond_with(resource, status: Devise.failure_status_code)
     end
   end
 
@@ -44,10 +44,10 @@ class Devise::PasswordsController < DeviseController
       else
         set_flash_message!(:notice, :updated_not_active)
       end
-      respond_with resource, location: after_resetting_password_path_for(resource)
+      respond_with resource, location: after_resetting_password_path_for(resource), status: Devise.redirect_status_code
     else
       set_minimum_password_length
-      respond_with resource
+      respond_with resource, status: Devise.failure_status_code
     end
   end
 

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -31,7 +31,7 @@ class Devise::RegistrationsController < DeviseController
     else
       clean_up_passwords resource
       set_minimum_password_length
-      respond_with resource
+      respond_with resource, status: Devise.failure_status_code
     end
   end
 
@@ -53,11 +53,11 @@ class Devise::RegistrationsController < DeviseController
       set_flash_message_for_update(resource, prev_unconfirmed_email)
       bypass_sign_in resource, scope: resource_name if sign_in_after_change_password?
 
-      respond_with resource, location: after_update_path_for(resource)
+      respond_with resource, location: after_update_path_for(resource), status: Devise.redirect_status_code
     else
       clean_up_passwords resource
       set_minimum_password_length
-      respond_with resource
+      respond_with resource, status: Devise.failure_status_code
     end
   end
 
@@ -67,7 +67,7 @@ class Devise::RegistrationsController < DeviseController
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     set_flash_message! :notice, :destroyed
     yield resource if block_given?
-    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name), status: Devise.redirect_status_code }
   end
 
   # GET /resource/cancel

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -77,7 +77,7 @@ class Devise::SessionsController < DeviseController
     # support returning empty response on GET request
     respond_to do |format|
       format.all { head :no_content }
-      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
+      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name), status: Devise.redirect_status_code }
     end
   end
 end

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -16,7 +16,7 @@ class Devise::UnlocksController < DeviseController
     if successfully_sent?(resource)
       respond_with({}, location: after_sending_unlock_instructions_path_for(resource))
     else
-      respond_with(resource)
+      respond_with(resource, status: Devise.failure_status_code)
     end
   end
 

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -227,6 +227,18 @@ module Devise
   mattr_accessor :sign_out_via
   @@sign_out_via = :delete
 
+  # The default status code for redirects on successful actions.
+  mattr_accessor :redirect_status_code
+  @@redirect_status_code = 302
+
+  # The default status code when a user fails to perform an action.
+  mattr_accessor :failure_status_code
+  @@failure_status_code = 200
+
+  # The default status code when a user is not authorized by Warden.
+  mattr_accessor :authentication_failure_status_code
+  @@authentication_failure_status_code = 200
+
   # The parent controller all Devise controllers inherits from.
   # Defaults to ApplicationController. This should be set early
   # in the initialization process and should be set to a string.


### PR DESCRIPTION
- Adds 303 (see_other) status codes to redirects
- Adds a 401 status code when Warden fails to authenticate.

- This does not directly allow Turbo streams, but does allow other solutions to hook into status codes to handle responses properly via Ajax. (Things like Mrujs or Request.js)

## Additional notes

totally open to discussion on this. This arised from a personal fork I was using and am happy to close the PR should another solution arise.