### PR TITLE
5505 - trigger setter instead of setting local var

### DIFF
--- a/app/controllers/devise_controller.rb
+++ b/app/controllers/devise_controller.rb
@@ -111,7 +111,7 @@ MESSAGE
       warden.authenticated?(resource_name)
     end
 
-    if authenticated && resource = warden.user(resource_name)
+    if authenticated && (self.resource = warden.user(resource_name))
       set_flash_message(:alert, 'already_authenticated', scope: 'devise.failure')
       redirect_to after_sign_in_path_for(resource)
     end


### PR DESCRIPTION
Fixes: https://github.com/heartcombo/devise/issues/5505

Changed `resource = warden.user(resource_name)` to `self.resource = warden.user(resource_name)` in [devise_controller#require_no_authentication](https://github.com/heartcombo/devise/blob/main/app/controllers/devise_controller.rb#L114) so that [setter resource =](https://github.com/heartcombo/devise/blob/main/app/controllers/devise_controller.rb#L94) is triggered and instance variable @user is populated.