### PR TITLE
Bug Fix: Devise Checkbox TRUE VALUES not compatible with HTML specs (missing "on" value)

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -60,7 +60,7 @@ module Devise
   NO_INPUT = []
 
   # True values used to check params
-  TRUE_VALUES = [true, 1, '1', 't', 'T', 'true', 'TRUE']
+  TRUE_VALUES = [true, 1, '1', 'on', 'ON', 't', 'T', 'true', 'TRUE']
 
   # Secret key used by the key generator
   mattr_accessor :secret_key


### PR DESCRIPTION
See:

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#attr-value
* https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type%3Dcheckbox)
* https://html.spec.whatwg.org/multipage/input.html#dom-input-value-default-on

This issue causes the remember me functionality not to work correctly, especially when overriding the default styles as check boxes by default in all major browsers send the value `on` as required by the HTML specifications.

See also:

https://stackoverflow.com/questions/5987075/devise-remember-me-not-working-localhost-issue