### PR TITLE
Add use_turbo configuration with default to false.

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: { devise_mapping.use_turbo }) do |f| %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: { turbo: devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: { turbo: Devise.use_turbo}) do |f| %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: { devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }, data: { turbo: Devise.use_turbo}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, data: { turbo: Devise.use_turbo}) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, data: { devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, data: { turbo: Devise.use_turbo}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, data: { devise_mapping.use_turbo }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, data: { turbo: devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, data: { turbo: Devise.use_turbo}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, data: { turbo: Devise.use_turbo}) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, data: { devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, data: { devise_mapping.use_turbo }) do |f| %>
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }, data: { turbo: devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, data: { turbo: Devise.use_turbo}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, data: { devise_mapping.use_turbo }) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, data: { turbo: devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, data: { turbo: Devise.use_turbo}) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }, data: { devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { devise_mapping.use_turbo }) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: Devise.use_turbo}) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: Devise.use_turbo}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Log in</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name), data: { devise_mapping.use_turbo }) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: devise_mapping.use_turbo }) do |f| %>
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Log in</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: Devise.use_turbo}) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), data: { devise_mapping.use_turbo }) do |f| %>
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Log in</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path(resource_name), data: { turbo: Devise.use_turbo}) do |f| %>
   <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend unlock instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }, data: { devise_mapping.use_turbo }) do |f| %>
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }, data: { turbo: devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend unlock instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }, data: { turbo: Devise.use_turbo}) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,6 +1,6 @@
 <h2>Resend unlock instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }, data: { turbo: Devise.use_turbo}) do |f| %>
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }, data: { devise_mapping.use_turbo }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -227,6 +227,10 @@ module Devise
   mattr_accessor :sign_out_via
   @@sign_out_via = :delete
 
+  # The default method used while signing out
+  mattr_accessor :use_turbo
+  @@use_turbo = false
+
   # The parent controller all Devise controllers inherits from.
   # Defaults to ApplicationController. This should be set early
   # in the initialization process and should be set to a string.

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -227,7 +227,7 @@ module Devise
   mattr_accessor :sign_out_via
   @@sign_out_via = :delete
 
-  # The default method used while signing out
+  # The default setting for using turbo on forms.
   mattr_accessor :use_turbo
   @@use_turbo = false
 

--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -25,7 +25,7 @@ module Devise
   #
   class Mapping #:nodoc:
     attr_reader :singular, :scoped_path, :path, :controllers, :path_names,
-                :class_name, :sign_out_via, :format, :used_routes, :used_helpers,
+                :class_name, :sign_out_via, :use_turbo, :format, :used_routes, :used_helpers,
                 :failure_app, :router_name
 
     alias :name :singular
@@ -64,7 +64,7 @@ module Devise
       @sign_out_via = options[:sign_out_via] || Devise.sign_out_via
       @format = options[:format]
 
-      @use_turbo = options[:use_turbo] || false
+      @use_turbo = options[:use_turbo] || Devise.use_turbo
 
       @router_name = options[:router_name]
 

--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -64,6 +64,8 @@ module Devise
       @sign_out_via = options[:sign_out_via] || Devise.sign_out_via
       @format = options[:format]
 
+      @use_turbo = options[:use_turbo] || false
+
       @router_name = options[:router_name]
 
       default_failure_app(options)

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -303,6 +303,11 @@ Devise.setup do |config|
   #   include Turbolinks::Controller
   # end
 
+  # ==> Hotwire configuration
+  # Use hotwire turbo for forms via 'data: {turbo: Devise.use_turbo}'.
+  # Default is: false in order to have Rails 7 working as default until it is fully supported.
+  config.use_turbo = false
+
   # ==> Configuration for :registerable
 
   # When set to false, does not sign a user in automatically after their password is


### PR DESCRIPTION
This PR enables Rails 7 and Devise to work out of the box.
Devise now opts out of turbo by default for its forms by making use of
data: { turbo: Devise.use_turbo} setting on forms.

I've seen this PR https://github.com/heartcombo/devise/pull/5487 but it is not configurable and hardcoded. So people that have opted into turbo can do this via a setting (maybe they fixed notifications by patching devise etc.).
I went with an approach that conforms to the style I've seen by inspecting the devise codebase.

My PR defaults to not using turbo in devise forms by default. I know this is a minor breaking change for people that might have patched the problem otherwise but it's the way to offer a sane default experience with Devise and Rails 7 until the maintainers decide on a real solution.
