### PR TITLE
Timeoutable timeout_in config should accept a proc

### DIFF
--- a/lib/devise/models/timeoutable.rb
+++ b/lib/devise/models/timeoutable.rb
@@ -32,7 +32,8 @@ module Devise
       end
 
       def timeout_in
-        self.class.timeout_in
+        config_value = self.class.timeout_in
+        config_value.is_a?(Proc) ? config_value.call(self) : config_value
       end
 
       private

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -188,6 +188,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
+  # Accepts a Duration or a proc, e.g. ->(user) { user.admin? ? nil : 30.minutes }
   # config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable

--- a/test/models/timeoutable_test.rb
+++ b/test/models/timeoutable_test.rb
@@ -42,6 +42,14 @@ class TimeoutableTest < ActiveSupport::TestCase
     end
   end
 
+  test 'Devise config option should accept a proc' do
+    user = new_user
+    user.instance_eval { def custom_timeout_in; 42.minutes end }
+    swap Devise, timeout_in: ->(user) { user.custom_timeout_in } do
+      assert_equal user.timeout_in, 42.minutes
+    end
+  end
+
   test 'required_fields should contain the fields that Devise uses' do
     assert_equal [], Devise::Models::Timeoutable.required_fields(User)
   end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -104,6 +104,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
+  # Accepts a Duration or a proc, e.g. ->(user) { user.admin? ? nil : 30.minutes }
   # config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable


### PR DESCRIPTION
Adding the ability to set timeout_in in the config file as a proc that evaluates with the user as an argument