### PR TITLE
Update navigational formats to accept turbo_Stream

### DIFF
--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -263,7 +263,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ['*/*', :html]
+  config.navigational_formats = ['*/*', :html, :turbo_stream]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete


### PR DESCRIPTION
![devise](https://user-images.githubusercontent.com/9162362/196010182-6e5411e9-ac9f-4f95-a5e0-7666114c4c83.png)
![devise 2](https://user-images.githubusercontent.com/9162362/196010183-a72a4ded-c2d6-41c8-baa5-616995eced13.png)

This pull request fixes the above two errors and it does it through editing the navigational formats of the template lib/generators/templates/devise.rb