### PR TITLE
Apply changes for rails-ujs and Turbo compatibility

### DIFF
--- a/app/controllers/devise/confirmations_controller.rb
+++ b/app/controllers/devise/confirmations_controller.rb
@@ -14,7 +14,7 @@ class Devise::ConfirmationsController < DeviseController
     if successfully_sent?(resource)
       respond_with({}, location: after_resending_confirmation_instructions_path_for(resource_name))
     else
-      respond_with(resource)
+      respond_with resource, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -18,7 +18,7 @@ class Devise::PasswordsController < DeviseController
     if successfully_sent?(resource)
       respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
     else
-      respond_with(resource)
+      respond_with resource, status: :unprocessable_entity
     end
   end
 
@@ -47,7 +47,7 @@ class Devise::PasswordsController < DeviseController
       respond_with resource, location: after_resetting_password_path_for(resource)
     else
       set_minimum_password_length
-      respond_with resource
+      respond_with resource, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -31,7 +31,7 @@ class Devise::RegistrationsController < DeviseController
     else
       clean_up_passwords resource
       set_minimum_password_length
-      respond_with resource
+      respond_with resource, status: :unprocessable_entity
     end
   end
 
@@ -57,7 +57,7 @@ class Devise::RegistrationsController < DeviseController
     else
       clean_up_passwords resource
       set_minimum_password_length
-      respond_with resource
+      respond_with resource, status: :unprocessable_entity
     end
   end
 
@@ -67,7 +67,7 @@ class Devise::RegistrationsController < DeviseController
     Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name)
     set_flash_message! :notice, :destroyed
     yield resource if block_given?
-    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name) }
+    respond_with_navigational(resource){ redirect_to after_sign_out_path_for(resource_name), status: :see_other }
   end
 
   # GET /resource/cancel

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -77,7 +77,7 @@ class Devise::SessionsController < DeviseController
     # support returning empty response on GET request
     respond_to do |format|
       format.all { head :no_content }
-      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
+      format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name), status: :see_other }
     end
   end
 end

--- a/app/controllers/devise/unlocks_controller.rb
+++ b/app/controllers/devise/unlocks_controller.rb
@@ -16,7 +16,7 @@ class Devise::UnlocksController < DeviseController
     if successfully_sent?(resource)
       respond_with({}, location: after_sending_unlock_instructions_path_for(resource))
     else
-      respond_with(resource)
+      respond_with resource, status: :unprocessable_entity
     end
   end
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -38,6 +38,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></p>
 
 <%= link_to "Back", :back %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,6 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), method: :post %><br />
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
   <% end %>
 <% end %>

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -217,7 +217,7 @@ module Devise
 
   # Which formats should be treated as navigational.
   mattr_accessor :navigational_formats
-  @@navigational_formats = ["*/*", :html]
+  @@navigational_formats = ["*/*", :html, :turbo_stream]
 
   # When set to true, signing out a user signs out all other scopes.
   mattr_accessor :sign_out_all_scopes

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -38,7 +38,7 @@ module Devise
       if http_auth?
         http_auth
       elsif warden_options[:recall]
-        recall
+        request_format == :turbo_stream ? redirect : recall
       else
         redirect
       end
@@ -167,7 +167,7 @@ module Devise
     end
 
     def skip_format?
-      %w(html */*).include? request_format.to_s
+      %w(html */* turbo_stream).include? request_format.to_s
     end
 
     # Choose whether we should respond in an HTTP authentication fashion,

--- a/lib/generators/templates/simple_form_for/registrations/edit.html.erb
+++ b/lib/generators/templates/simple_form_for/registrations/edit.html.erb
@@ -30,6 +30,6 @@
 
 <h3>Cancel my account</h3>
 
-<p>Unhappy? <%= link_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
+<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></p>
 
 <%= link_to "Back", :back %>

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -119,7 +119,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
 
     delete destroy_admin_session_path
     assert_response :redirect
-    assert_redirected_to root_path
+    assert_see_other_to root_path
 
     get root_path
     assert_contain 'Signed out successfully'
@@ -129,7 +129,7 @@ class AuthenticationSanityTest < Devise::IntegrationTest
   test 'unauthenticated admin set message on sign out' do
     delete destroy_admin_session_path
     assert_response :redirect
-    assert_redirected_to root_path
+    assert_see_other_to root_path
 
     get root_path
     assert_contain 'Signed out successfully'

--- a/test/integration/omniauthable_test.rb
+++ b/test/integration/omniauthable_test.rb
@@ -126,15 +126,19 @@ class OmniauthableIntegrationTest < Devise::IntegrationTest
     end
   end
 
-  test "generates a link to authenticate with provider" do
+  test "generates a button to authenticate with provider" do
     visit "/users/sign_in"
-    assert_select "a[href=?][data-method='post']", "/users/auth/facebook", text: "Sign in with FaceBook"
+    assert_select "form[action=?]", "/users/auth/facebook" do
+      assert_select "input[value=?]", "Sign in with FaceBook"
+    end
   end
 
-  test "generates a proper link when SCRIPT_NAME is set" do
+  test "generates a proper button when SCRIPT_NAME is set" do
     header 'SCRIPT_NAME', '/q'
     visit "/users/sign_in"
-    assert_select "a[href=?][data-method='post']", "/q/users/auth/facebook", text: "Sign in with FaceBook"
+    assert_select "form[action=?]", "/q/users/auth/facebook" do
+      assert_select "input[value=?]", "Sign in with FaceBook"
+    end
   end
 
   test "handles callback error parameter according to the specification" do

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -76,7 +76,7 @@ class PasswordTest < Devise::IntegrationTest
         fill_in 'email', with: 'foo@bar.com'
       end
 
-      assert_response :success
+      assert_response :unprocessable_entity
       assert_current_url '/users/password'
       assert_have_selector "input[type=email][value='foo@bar.com']"
       assert_contain 'not found'
@@ -102,7 +102,7 @@ class PasswordTest < Devise::IntegrationTest
         fill_in 'email', with: ' foo@bar.com '
       end
 
-      assert_response :success
+      assert_response :unprocessable_entity
       assert_current_url '/users/password'
       assert_have_selector "input[type=email][value=' foo@bar.com ']"
       assert_contain 'not found'
@@ -132,7 +132,7 @@ class PasswordTest < Devise::IntegrationTest
       fill_in 'email', with: 'invalid.test@test.com'
     end
 
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_current_url '/users/password'
     assert_have_selector "input[type=email][value='invalid.test@test.com']"
     assert_contain 'not found'
@@ -156,7 +156,7 @@ class PasswordTest < Devise::IntegrationTest
     user = create_user
     reset_password reset_password_token: 'invalid_reset_password'
 
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_current_url '/users/password'
     assert_have_selector '#error_explanation'
     assert_contain %r{Reset password token(.*)invalid}
@@ -170,7 +170,7 @@ class PasswordTest < Devise::IntegrationTest
       fill_in 'Confirm new password', with: 'other_password'
     end
 
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_current_url '/users/password'
     assert_have_selector '#error_explanation'
     assert_contain "Password confirmation doesn't match Password"
@@ -192,7 +192,7 @@ class PasswordTest < Devise::IntegrationTest
     request_forgot_password
 
     reset_password {  fill_in 'Confirm new password', with: 'other_password' }
-    assert_response :success
+    assert_response :unprocessable_entity
     assert_have_selector '#error_explanation'
     refute user.reload.valid_password?('987654321')
 

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -94,7 +94,7 @@ class SessionTimeoutTest < Devise::IntegrationTest
     delete destroy_user_session_path
 
     assert_response :redirect
-    assert_redirected_to root_path
+    assert_see_other_to root_path
     follow_redirect!
     assert_contain 'Signed out successfully'
   end
@@ -109,7 +109,7 @@ class SessionTimeoutTest < Devise::IntegrationTest
     follow_redirect!
 
     assert_response :success
-    assert_contain 'Sign in'
+    assert_contain 'Log in'
     refute warden.authenticated?(:user)
   end
 

--- a/test/support/integration.rb
+++ b/test/support/integration.rb
@@ -67,6 +67,13 @@ class ActionDispatch::IntegrationTest
     assert_url url, @integration_session.headers["Location"]
   end
 
+  def assert_see_other_to(url)
+    assert_equal 303, @integration_session.status,
+                 "Expected status to be 303, got #{@integration_session.status}"
+
+    assert_url url, @integration_session.headers["Location"]
+  end
+
   def assert_current_url(expected)
     assert_url expected, current_url
   end


### PR DESCRIPTION
## Purpose
I want to use Devise easily for both Rails 6.1(rails-ujs) and Rails 7.0(Turbo). Typical steps are like this:

1. rails new
1. echo 'gem "devise"' >> Gemfile
1. bundle install
1. rails g devise:install
1. rails g devise User
1. rails db:migrate
1. [edit application controller](https://github.com/JunichiIto/devise-rails-6-1-sandbox/blob/main/app/controllers/application_controller.rb#L2-L8)
1. [add edit account link and sign out button](https://github.com/JunichiIto/devise-rails-6-1-sandbox/blob/main/app/views/home/index.html.erb#L5-L10)
1. rails c

My PR enables it.

## Notable changes

### Status codes
- Returns 422 Unprocessable Entity status instead of 200 when validation error occurs for the following actions:

```
POST /resource/confirmation
POST /resource/password
PUT  /resource/password
POST /resource
PUT  /resource
POST /resource/unlock
```

- Returns 303 See Other status instead of 302 for the following actions:

```
DELETE /resource
DELETE /resource/sign_out
```

- Returns 302 status instead of 200 when sign-in fails for turbo_stream requests.

### Views
- Recommends to use `button_to` to sign-out because it works for both rails-ujs and Turbo:

```erb
<%# This works for rails-ujs and Turbo %>
<%= button_to 'Sign out', destroy_user_session_path, method: :delete %>
```

- If you want to use `link_to` to sign-out, please choose one or the other:

```erb
<%# Turbo %>
<%= link_to 'Sign out', destroy_user_session_path, data: { turbo_method: :delete } %>

<%# rails-ujs %>
<%= link_to 'Sign out', destroy_user_session_path, method: :delete %>
```

## Example apps

I created example apps for Turbo and rails-ujs with my version of Devise. They also have system tests.

- [Rails 7.0 + Turbo](https://github.com/JunichiIto/devise-rails-7-sandbox/tree/with-customized-devise) ([diff to setup](https://github.com/JunichiIto/devise-rails-7-sandbox/compare/d4ff16c63bff31c47b9ef126da03396341f8683b...abf02f41f0f4f90ec47030608d1713b90cd778e3))
- [Rails 6.1 + rails-ujs](https://github.com/JunichiIto/devise-rails-6-1-sandbox) ([diff to setup](https://github.com/JunichiIto/devise-rails-6-1-sandbox/compare/438f8f8a0e76ca31dfcd9111fc7e3852a33a28d7...0ae2b80cd6f2678375636ced561ac83226cce785))

Please feel free ask me if you have any questions or requests.
