### PR TITLE
Fix deprecation warning in ParameterSanitizer#permit

### DIFF
--- a/lib/devise/parameter_sanitizer.rb
+++ b/lib/devise/parameter_sanitizer.rb
@@ -107,7 +107,10 @@ module Devise
     #
     #
     # Returns nothing.
-    def permit(action, keys: nil, except: nil, &block)
+    def permit(action, opts = {}, &block)
+      keys = opts.delete(:keys)
+      except = opts.delete(:except)
+
       if block_given?
         @permitted[action] = block
       end


### PR DESCRIPTION
Hello first time here

I'm using Devise 4.8.1 with Rails and I'm upgrading my Rails version to 7.0.4
When I ran the tests on my app, I get these deprecation warnings:
```
app/models/user/parameter_sanitizer.rb:24: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/devise-4.8.1/lib/devise/parameter_sanitizer.rb:110: warning: The called method `permit' is defined here
```
There were plenty of them, so I decided to `bundle open devise`.
I edited the file, ran the  tests on my app, and the deprecation warnings about the `ParameterSanitizer` were gone.
I put what I wrote on this PR.