### PR TITLE
Fix frozen string in validatable module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* bug fixes
+  * Fix frozen string exception in validatable. [#5563](https://github.com/heartcombo/devise/pull/5563) [#5465](https://github.com/heartcombo/devise/pull/5465) [@mameier](https://github.com/mameier)
 
 ### 4.9.0 - 2023-02-17
 

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -47,7 +47,7 @@ module Devise
         unavailable_validations = VALIDATIONS.select { |v| !base.respond_to?(v) }
 
         unless unavailable_validations.empty?
-          raise "Could not use :validatable module since #{base} does not respond " <<
+          raise "Could not use :validatable module since #{base} does not respond " \
                 "to the following methods: #{unavailable_validations.to_sentence}."
         end
       end

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -110,9 +110,12 @@ class ValidatableTest < ActiveSupport::TestCase
   end
 
   test 'should not be included in objects with invalid API' do
-    assert_raise RuntimeError do
+    exception = assert_raise RuntimeError do
       Class.new.send :include, Devise::Models::Validatable
     end
+
+    expected_message = /Could not use :validatable module since .* does not respond to the following methods: validates_presence_of.*/
+    assert_match expected_message, exception.message
   end
 
   test 'required_fields should be an empty array' do


### PR DESCRIPTION
Expand tests to check for the actual validatable exception message

This was raising a `FrozenError` on Ruby < 3 where interpolated strings
were considered frozen. This [changed in Ruby 3], since such strings are
dynamic there's no point in freezing them by default.

The test wasn't catching this because `FrozenError` actually inherits
from `RuntimeError`:

>> FrozenError.ancestors
=> [FrozenError, RuntimeError, StandardError, Exception, Object ...]

So the exception check passed. Now we're also checking for the error
message to ensure it raised the exception we really expected there.

Closes https://github.com/heartcombo/devise/pull/5465