### PR TITLE
Respect locale set by controller in the failure app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+* bug fixes
+  * Respect locale set by controller in failure app. Devise will carry over the current I18n.locale option when triggering authentication, and will wrap the failure app call with it. [#5567](https://github.com/heartcombo/devise/pull/5567)
+
 ### 4.9.3 - 2023-10-11
 
 * enhancements

--- a/app/controllers/devise/sessions_controller.rb
+++ b/app/controllers/devise/sessions_controller.rb
@@ -45,7 +45,7 @@ class Devise::SessionsController < DeviseController
   end
 
   def auth_options
-    { scope: resource_name, recall: "#{controller_path}#new" }
+    { scope: resource_name, recall: "#{controller_path}#new", locale: I18n.locale }
   end
 
   def translation_scope

--- a/lib/devise/controllers/helpers.rb
+++ b/lib/devise/controllers/helpers.rb
@@ -46,6 +46,7 @@ module Devise
                 mappings.unshift mappings.delete(favorite.to_sym) if favorite
                 mappings.each do |mapping|
                   opts[:scope] = mapping
+                  opts[:locale] = I18n.locale
                   warden.authenticate!(opts) if !devise_controller? || opts.delete(:force)
                 end
               end
@@ -115,6 +116,7 @@ module Devise
         class_eval <<-METHODS, __FILE__, __LINE__ + 1
           def authenticate_#{mapping}!(opts = {})
             opts[:scope] = :#{mapping}
+            opts[:locale] = I18n.locale
             warden.authenticate!(opts) if !devise_controller? || opts.delete(:force)
           end
 

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -18,6 +18,11 @@ module Devise
 
     delegate :flash, to: :request
 
+    include AbstractController::Callbacks
+    around_action do |failure_app, action|
+      I18n.with_locale(failure_app.i18n_locale, &action)
+    end
+
     def self.call(env)
       @respond ||= action(:respond)
       @respond.call(env)
@@ -107,13 +112,17 @@ module Devise
         options[:default] = [message]
         auth_keys = scope_class.authentication_keys
         keys = (auth_keys.respond_to?(:keys) ? auth_keys.keys : auth_keys).map { |key| scope_class.human_attribute_name(key) }
-        options[:authentication_keys] = keys.join(I18n.translate(:"support.array.words_connector"))
+        options[:authentication_keys] = keys.join(I18n.t(:"support.array.words_connector"))
         options = i18n_options(options)
 
         I18n.t(:"#{scope}.#{message}", **options)
       else
         message.to_s
       end
+    end
+
+    def i18n_locale
+      warden_options[:locale]
     end
 
     def redirect_url

--- a/test/controllers/helpers_test.rb
+++ b/test/controllers/helpers_test.rb
@@ -64,30 +64,30 @@ class ControllerAuthenticatableTest < Devise::ControllerTestCase
   end
 
   test 'proxy authenticate_user! to authenticate with user scope' do
-    @mock_warden.expects(:authenticate!).with({ scope: :user })
+    @mock_warden.expects(:authenticate!).with({ scope: :user, locale: :en })
     @controller.authenticate_user!
   end
 
   test 'proxy authenticate_user! options to authenticate with user scope' do
-    @mock_warden.expects(:authenticate!).with({ scope: :user, recall: "foo" })
+    @mock_warden.expects(:authenticate!).with({ scope: :user, recall: "foo", locale: :en })
     @controller.authenticate_user!(recall: "foo")
   end
 
   test 'proxy authenticate_admin! to authenticate with admin scope' do
-    @mock_warden.expects(:authenticate!).with({ scope: :admin })
+    @mock_warden.expects(:authenticate!).with({ scope: :admin, locale: :en })
     @controller.authenticate_admin!
   end
 
   test 'proxy authenticate_[group]! to authenticate!? with each scope' do
     [:user, :admin].each do |scope|
-      @mock_warden.expects(:authenticate!).with({ scope: scope })
+      @mock_warden.expects(:authenticate!).with({ scope: scope, locale: :en })
       @mock_warden.expects(:authenticate?).with(scope: scope).returns(false)
     end
     @controller.authenticate_commenter!
   end
 
   test 'proxy authenticate_publisher_account! to authenticate with namespaced publisher account scope' do
-    @mock_warden.expects(:authenticate!).with({ scope: :publisher_account })
+    @mock_warden.expects(:authenticate!).with({ scope: :publisher_account, locale: :en })
     @controller.authenticate_publisher_account!
   end
 

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -273,6 +273,15 @@ class AuthenticationRedirectTest < Devise::IntegrationTest
     assert_contain 'You need to sign in or sign up before continuing.'
   end
 
+  test 'redirect from warden respects i18n locale set at the controller' do
+    get admins_path(locale: "pt-BR")
+
+    assert_redirected_to new_admin_session_path
+    follow_redirect!
+
+    assert_contain 'Para continuar, faça login ou registre-se.'
+  end
+
   test 'redirect to default url if no other was configured' do
     sign_in_as_user
     assert_template 'home/index'

--- a/test/rails_app/app/controllers/admins_controller.rb
+++ b/test/rails_app/app/controllers/admins_controller.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 class AdminsController < ApplicationController
+  around_action :set_locale
   before_action :authenticate_admin!
 
   def index
+  end
+
+  private
+
+  def set_locale
+    I18n.with_locale(params[:locale] || I18n.default_locale) { yield }
   end
 end

--- a/test/support/locale/pt-BR.yml
+++ b/test/support/locale/pt-BR.yml
@@ -1,0 +1,5 @@
+pt-BR:
+  devise:
+    failure:
+      invalid: "%{authentication_keys} ou senha inválidos."
+      unauthenticated: "Para continuar, faça login ou registre-se."

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,7 +10,7 @@ require "rails_app/config/environment"
 require "rails/test_help"
 require "orm/#{DEVISE_ORM}"
 
-I18n.load_path << File.expand_path("../support/locale/en.yml", __FILE__)
+I18n.load_path.concat Dir["#{File.dirname(__FILE__)}/support/locale/*.yml"]
 
 require 'mocha/minitest'
 require 'timecop'


### PR DESCRIPTION
A common usage of I18n with different locales is to create some around callback in the application controller that sets the locale for the entire action, via params/url/user/etc., which ensure the locale is respected for the duration of that action, and resets at the end.

Devise was not respecting the locale when the authenticate failed and triggered the failure app, because that happens in a warden middleware right up in the change, by that time the controller around callback had already reset the locale back to its default, and the failure app would just translate flash messages using the default locale.

Now we are passing the current locale down to the failure app via warden options, and wrapping it with an around callback, which makes the failure app respect the set I18n locale by the controller at the time the authentication failure is triggered, working as expected. (much more like a normal controller would.)

I chose to introduce a callback in the failure app so we could wrap the whole `respond` action processing rather than adding individual `locale` options to the `I18n.t` calls, because that should ensure other possible `I18n.t` calls from overridden failure apps would respect the set locale as well, and makes it more like one would implement in a controller. I don't recommend people using callbacks in their own failure apps though, as this is not going to be documented as a "feature" of failures apps, it's considered "internal" and could be refactored at any point.

It is possible to override the locale with the new `i18n_locale` method, which simply defaults to the passed locale from the controller.

Closes #5247
Closes #5246

Related to: #3052, #4823, and possible others already closed. Related to warden: (may be closed there afterwards) https://github.com/wardencommunity/warden/issues/180 https://github.com/wardencommunity/warden/issues/170