### PR TITLE
Respect redirect status code when recalling the action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   * Allow resource class scopes to override the global configuration for `sign_in_after_reset_password` behaviour. [#5429](https://github.com/heartcombo/devise/pull/5429) [@mattr](https://github.com/mattr)
 
 * bug fixes
+  * Failure app will respond with configured `redirect_status` instead of `error_status` if the recall app returns a redirect status (300..399) [#5573](https://github.com/heartcombo/devise/pull/5573)
   * Fix frozen string exception in validatable. [#5563](https://github.com/heartcombo/devise/pull/5563) [#5465](https://github.com/heartcombo/devise/pull/5465) [@mameier](https://github.com/mameier)
 
 ### 4.9.0 - 2023-02-17

--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -72,7 +72,9 @@ module Devise
 
       flash.now[:alert] = i18n_message(:invalid) if is_flashing_format?
       self.response = recall_app(warden_options[:recall]).call(request.env).tap { |response|
-        response[0] = Rack::Utils.status_code(Devise.responder.error_status)
+        response[0] = Rack::Utils.status_code(
+          response[0].in?(300..399) ? Devise.responder.redirect_status : Devise.responder.error_status
+        )
       }
     end
 

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -371,6 +371,35 @@ class FailureTest < ActiveSupport::TestCase
         end
       end
     end
+
+    # TODO: remove conditional/else when supporting only responders 3.1+
+    if ActionController::Responder.respond_to?(:error_status=)
+      test 'respects the configured responder `error_status` for the status code' do
+        swap Devise.responder, error_status: :unprocessable_entity do
+          env = {
+            "warden.options" => { recall: "devise/sessions#new", attempted_path: "/users/sign_in" },
+            "devise.mapping" => Devise.mappings[:user],
+            "warden" => stub_everything
+          }
+          call_failure(env)
+
+          assert_equal 422, @response.first
+          assert_includes @response.third.body, 'Invalid Email or password.'
+        end
+      end
+    else
+      test 'uses default hardcoded responder `error_status` for the status code since responders version does not support configuring it' do
+        env = {
+          "warden.options" => { recall: "devise/sessions#new", attempted_path: "/users/sign_in" },
+          "devise.mapping" => Devise.mappings[:user],
+          "warden" => stub_everything
+        }
+        call_failure(env)
+
+        assert_equal 200, @response.first
+        assert_includes @response.third.body, 'Invalid Email or password.'
+      end
+    end
   end
 
   context "Lazy loading" do

--- a/test/failure_app_test.rb
+++ b/test/failure_app_test.rb
@@ -387,6 +387,19 @@ class FailureTest < ActiveSupport::TestCase
           assert_includes @response.third.body, 'Invalid Email or password.'
         end
       end
+
+      test 'respects the configured responder `redirect_status` if the recall app returns a redirect status code' do
+        swap Devise.responder, redirect_status: :see_other do
+          env = {
+            "warden.options" => { recall: "devise/registrations#cancel", attempted_path: "/users/cancel" },
+            "devise.mapping" => Devise.mappings[:user],
+            "warden" => stub_everything
+          }
+          call_failure(env)
+
+          assert_equal 303, @response.first
+        end
+      end
     else
       test 'uses default hardcoded responder `error_status` for the status code since responders version does not support configuring it' do
         env = {
@@ -398,6 +411,17 @@ class FailureTest < ActiveSupport::TestCase
 
         assert_equal 200, @response.first
         assert_includes @response.third.body, 'Invalid Email or password.'
+      end
+
+      test 'users default hardcoded responder `redirect_status` for the status code since responders version does not support configuring it' do
+        env = {
+          "warden.options" => { recall: "devise/registrations#cancel", attempted_path: "/users/cancel" },
+          "devise.mapping" => Devise.mappings[:user],
+          "warden" => stub_everything
+        }
+        call_failure(env)
+
+        assert_equal 302, @response.first
       end
     end
   end


### PR DESCRIPTION
It appears some people use the recall functionality with a redirect
response, and Devise starting on version 4.9 was overriding that status
code to the configured `error_status` for better Turbo support, which
broke the redirect functionality / expectation.

While I don't think it's really great usage of the recall functionality,
or at least it was unexpected usage, it's been working like that
basically forever where recalling would use the status code of the
recalled action, so this at least keeps it more consistent with that
behavior by respecting redirects and keeping that response as a redirect
based on the configured status, which should also work with Turbo I
believe, and makes this less of a breaking change.

Closes https://github.com/heartcombo/devise/issues/5570
Closes https://github.com/heartcombo/devise/issues/5561 (it was closed previously, but related / closes with an
actual change now.)