### PR TITLE
Improve support for Devise in apps with multiple ORMs loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * enhancements
   * Allow resource class scopes to override the global configuration for `sign_in_after_reset_password` behaviour. [#5429](https://github.com/heartcombo/devise/pull/5429) [@mattr](https://github.com/mattr)
   * Refactor conditional dirty tracking logic to a centralized module to simplify usage throughout the codebase. [#5575](https://github.com/heartcombo/devise/pull/5575)
+  * Improve support for Devise in apps with Active Record and Mongoid ORMs loaded, so it does not incorrectly uses new Active Record dirty tracking APIs with a Mongoid Devise model. [#5576](https://github.com/heartcombo/devise/pull/5576)
 
 * bug fixes
   * Fix frozen string exception in validatable. [#5563](https://github.com/heartcombo/devise/pull/5563) [#5465](https://github.com/heartcombo/devise/pull/5465) [@mameier](https://github.com/mameier)

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -13,7 +13,7 @@ module Devise
   autoload :Encryptor,          'devise/encryptor'
   autoload :FailureApp,         'devise/failure_app'
   autoload :OmniAuth,           'devise/omniauth'
-  autoload :OrmDirtyTracking,   'devise/orm_dirty_tracking'
+  autoload :Orm,                'devise/orm'
   autoload :ParameterFilter,    'devise/parameter_filter'
   autoload :ParameterSanitizer, 'devise/parameter_sanitizer'
   autoload :TestHelpers,        'devise/test_helpers'

--- a/lib/devise/models.rb
+++ b/lib/devise/models.rb
@@ -84,7 +84,7 @@ module Devise
       end
 
       devise_modules_hook! do
-        include Devise::OrmDirtyTracking
+        include Devise::Orm
         include Devise::Models::Authenticatable
 
         selected_modules.each do |m|

--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -48,7 +48,7 @@ module Devise
       included do
         before_create :generate_confirmation_token, if: :confirmation_required?
         after_create :skip_reconfirmation_in_callback!, if: :send_confirmation_notification?
-        if defined?(ActiveRecord) && self < ActiveRecord::Base # ActiveRecord
+        if Devise::Orm.active_record?(self) # ActiveRecord
           after_commit :send_on_create_confirmation_instructions, on: :create, if: :send_confirmation_notification?
           after_commit :send_reconfirmation_instructions, on: :update, if: :reconfirmation_required?
         else # Mongoid


### PR DESCRIPTION
Devise is able to work with a specific ORM, either Active Record or Mongoid, but nothing stops apps from using multiple ORMs within the same application -- they just need to pick one to use with Devise. That's generally determined by the require that is added to the Devise initializer, that will load up either ORM's extensions so you can call things like `devise` on your model to set it up.

However, some conditional logic in Devise, more specifically around dirty tracking, was only considering having Active Record loaded up after a certain version, to determine which methods to call in parts of the implementation. In a previous change we refactored all that dirty tracking code into this `OrmDirtyTracking` module to make it easier to view all the methods that were being conditionally called, and now we're repurposing this into a more generic `Orm` module (that's nodoc'ed by default) so that upon including it, we can conditionally include the proper dirty tracking extensions but also check whether the including model is really Active Record or not, so we can trigger the correct dirty tracking behavior for Mongoid as well if both are loaded on the same app, whereas previously the Mongoid behavior would always use the new Active Record behavior, but support may differ.

While we are also working to ensure the latest versions of Mongoid are fully running with Devise, this should improve the situation by giving apps with multiple ORMs loaded a chance to rely on some of these Devise bits of functionality better now that weren't working properly before without some monkey-patching on their end.

Closes #5539
Closes #4542