### PR TITLE
Make encryptor pluggable

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -67,6 +67,11 @@ module Devise
   mattr_accessor :secret_key
   @@secret_key = nil
 
+  # Encryptor defaults to :bcrypt but might be an object
+  # that implements the encryptor API
+  mattr_accessor :encryptor
+  @@encryptor = :bcrypt
+
   # Custom domain or key for cookies. Not set by default
   mattr_accessor :rememberable_options
   @@rememberable_options = {}

--- a/lib/devise/encryptors/bcrypt_encryptor.rb
+++ b/lib/devise/encryptors/bcrypt_encryptor.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'bcrypt'
+
+module Devise
+  module Encryptors
+    module BCryptEncryptor
+      def self.digest(klass, password)
+        if klass.pepper.present?
+          password = "#{password}#{klass.pepper}"
+        end
+        ::BCrypt::Password.create(password, cost: klass.stretches).to_s
+      end
+
+      def self.compare(klass, hashed_password, password)
+        return false if hashed_password.blank?
+        bcrypt   = ::BCrypt::Password.new(hashed_password)
+        password = ::BCrypt::Engine.hash_secret("#{password}#{klass.pepper}", bcrypt.salt)
+        Devise.secure_compare(password, hashed_password)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an alternative solution to #5579 where I sketched out an Argon2 Encryptor inside Devise.

If that would interest you I can gladly make another  PR. However here I only make the encryptor pluggable which would be of great help for my organisation as we are under heavy pressure (which I fail to understand) form the customer to use Argon2.