### PR TITLE
Use a dedicated ActiveSupport::Deprecation

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -4,7 +4,7 @@ module DeviseHelper
   # Retain this method for backwards compatibility, deprecated in favor of modifying the
   # devise/shared/error_messages partial.
   def devise_error_messages!
-    ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+    Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
       [Devise] `DeviseHelper#devise_error_messages!` is deprecated and will be
       removed in the next major version.
 

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -521,8 +521,12 @@ module Devise
     res == 0
   end
 
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new("5.0", "Devise")
+  end
+
   def self.activerecord51? # :nodoc:
-    ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+    deprecator.warn <<-DEPRECATION.strip_heredoc
       [Devise] `Devise.activerecord51?` is deprecated and will be removed in the next major version.
       It is a non-public method that's no longer used internally, but that other libraries have been relying on.
     DEPRECATION

--- a/lib/devise/controllers/sign_in_out.rb
+++ b/lib/devise/controllers/sign_in_out.rb
@@ -38,7 +38,7 @@ module Devise
         expire_data_after_sign_in!
 
         if options[:bypass]
-          ActiveSupport::Deprecation.warn(<<-DEPRECATION.strip_heredoc, caller)
+          Devise.deprecator.warn(<<-DEPRECATION.strip_heredoc, caller)
           [Devise] bypass option is deprecated and it will be removed in future version of Devise.
           Please use bypass_sign_in method instead.
           Example:

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -62,7 +62,7 @@ module Devise
         :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at]
 
       include Devise::DeprecatedConstantAccessor
-      deprecate_constant "BLACKLIST_FOR_SERIALIZATION", "Devise::Models::Authenticatable::UNSAFE_ATTRIBUTES_FOR_SERIALIZATION"
+      deprecate_constant "BLACKLIST_FOR_SERIALIZATION", "Devise::Models::Authenticatable::UNSAFE_ATTRIBUTES_FOR_SERIALIZATION", deprecator: Devise.deprecator
 
       included do
         class_attribute :devise_modules, instance_writer: false

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -86,7 +86,7 @@ module Devise
       # is also rejected as long as it is also blank.
       def update_with_password(params, *options)
         if options.present?
-          ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+          Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
             [Devise] The second argument of `DatabaseAuthenticatable#update_with_password`
             (`options`) is deprecated and it will be removed in the next major version.
             It was added to support a feature deprecated in Rails 4, so you can safely remove it
@@ -128,7 +128,7 @@ module Devise
       #
       def update_without_password(params, *options)
         if options.present?
-          ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+          Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
             [Devise] The second argument of `DatabaseAuthenticatable#update_without_password`
             (`options`) is deprecated and it will be removed in the next major version.
             It was added to support a feature deprecated in Rails 4, so you can safely remove it

--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -17,6 +17,10 @@ module Devise
       app.reload_routes! if Devise.reload_routes
     end
 
+    initializer "devise.deprecator" do |app|
+      app.deprecators[:devise] = Devise.deprecator if app.respond_to?(:deprecators)
+    end
+
     initializer "devise.url_helpers" do
       Devise.include_helpers(Devise::Controllers)
     end

--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -69,7 +69,7 @@ module Devise
           scope = resource
           resource = deprecated
 
-          ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+          Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
             [Devise] sign_in(:#{scope}, resource) on controller tests is deprecated and will be removed from Devise.
             Please use sign_in(resource, scope: :#{scope}) instead.
           DEPRECATION

--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -4,7 +4,7 @@ module Devise
   module TestHelpers
     def self.included(base)
       base.class_eval do
-        ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+        Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
           [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise.
           For controller tests, please include `Devise::Test::ControllerHelpers` instead.
         DEPRECATION

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -108,6 +108,8 @@ class DeviseTest < ActiveSupport::TestCase
   end
 
   test 'Devise.activerecord51? deprecation' do
-    assert_deprecated { Devise.activerecord51? }
+    assert_deprecated("`Devise.activerecord51?` is deprecated", Devise.deprecator) do
+      Devise.activerecord51?
+    end
   end
 end

--- a/test/models/serializable_test.rb
+++ b/test/models/serializable_test.rb
@@ -32,7 +32,9 @@ class SerializableTest < ActiveSupport::TestCase
   end
 
   test 'constant `BLACKLIST_FOR_SERIALIZATION` is deprecated' do
-    assert_deprecated { Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION }
+    assert_deprecated("Devise::Models::Authenticatable::UNSAFE_ATTRIBUTES_FOR_SERIALIZATION", Devise.deprecator) do
+      Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION
+    end
   end
 
   def assert_key(key, subject)

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -8,4 +8,10 @@ class RailsTest < ActiveSupport::TestCase
     assert_equal :load_config_initializers, initializer.after
     assert_equal :build_middleware_stack, initializer.before
   end
+
+  if Devise::Test.rails71_and_up?
+    test 'deprecator is added to application deprecators' do
+      assert_not_nil Rails.application.deprecators[:devise]
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,19 @@ end
 if ActiveSupport.respond_to?(:test_order)
   ActiveSupport.test_order = :random
 end
+class ActiveSupport::TestCase
+  if ActiveSupport.version < Gem::Version.new("5.0")
+    def assert_deprecated(match, deprecator)
+      super(match) do
+        behavior = deprecator.behavior
+        deprecator.behavior = ActiveSupport::Deprecation.behavior
+        yield
+      ensure
+        deprecator.behavior = behavior
+      end
+    end
+  end
+end
 
 OmniAuth.config.logger = Logger.new('/dev/null')
 


### PR DESCRIPTION
Rails 7.1 will deprecate using the singleton ActiveSupport::Deprecation instance (https://github.com/rails/rails/pull/47354). This defines one for the gem and uses it.