### PR TITLE
Allow `password_length: nil (or false)` to skip password length validation

### DIFF
--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -34,7 +34,7 @@ module Devise
 
           validates_presence_of     :password, if: :password_required?
           validates_confirmation_of :password, if: :password_required?
-          validates_length_of       :password, within: password_length, allow_blank: true
+          validates_length_of(:password, within: password_length, allow_blank: true) if password_length
         end
       end
 


### PR DESCRIPTION
I have custom validation logic for password length, and as such I'd like to skip the default validation from Devise. Please let me know if this patch would be accepted, and if so, I'll add tests.