### PR TITLE
Introduce `Devise.deprecator`

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -4,7 +4,7 @@ module DeviseHelper
   # Retain this method for backwards compatibility, deprecated in favor of modifying the
   # devise/shared/error_messages partial.
   def devise_error_messages!
-    ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+    Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
       [Devise] `DeviseHelper#devise_error_messages!` is deprecated and will be
       removed in the next major version.
 

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -365,6 +365,10 @@ module Devise
     mapping
   end
 
+  def self.deprecator
+    @deprecator ||= ActiveSupport::Deprecation.new("5.0", "Devise")
+  end
+
   # Register available devise modules. For the standard modules that Devise provides, this method is
   # called from lib/devise/modules.rb. Third-party modules need to be added explicitly using this method.
   #
@@ -522,7 +526,7 @@ module Devise
   end
 
   def self.activerecord51? # :nodoc:
-    ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+    Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
       [Devise] `Devise.activerecord51?` is deprecated and will be removed in the next major version.
       It is a non-public method that's no longer used internally, but that other libraries have been relying on.
     DEPRECATION

--- a/lib/devise/controllers/sign_in_out.rb
+++ b/lib/devise/controllers/sign_in_out.rb
@@ -38,7 +38,7 @@ module Devise
         expire_data_after_sign_in!
 
         if options[:bypass]
-          ActiveSupport::Deprecation.warn(<<-DEPRECATION.strip_heredoc, caller)
+          Devise.deprecator.warn(<<-DEPRECATION.strip_heredoc, caller)
           [Devise] bypass option is deprecated and it will be removed in future version of Devise.
           Please use bypass_sign_in method instead.
           Example:

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -62,7 +62,7 @@ module Devise
         :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at]
 
       include Devise::DeprecatedConstantAccessor
-      deprecate_constant "BLACKLIST_FOR_SERIALIZATION", "Devise::Models::Authenticatable::UNSAFE_ATTRIBUTES_FOR_SERIALIZATION"
+      deprecate_constant "BLACKLIST_FOR_SERIALIZATION", "Devise::Models::Authenticatable::UNSAFE_ATTRIBUTES_FOR_SERIALIZATION", deprecator: Devise.deprecator
 
       included do
         class_attribute :devise_modules, instance_writer: false

--- a/lib/devise/models/database_authenticatable.rb
+++ b/lib/devise/models/database_authenticatable.rb
@@ -86,7 +86,7 @@ module Devise
       # is also rejected as long as it is also blank.
       def update_with_password(params, *options)
         if options.present?
-          ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+          Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
             [Devise] The second argument of `DatabaseAuthenticatable#update_with_password`
             (`options`) is deprecated and it will be removed in the next major version.
             It was added to support a feature deprecated in Rails 4, so you can safely remove it
@@ -128,7 +128,7 @@ module Devise
       #
       def update_without_password(params, *options)
         if options.present?
-          ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+          Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
             [Devise] The second argument of `DatabaseAuthenticatable#update_without_password`
             (`options`) is deprecated and it will be removed in the next major version.
             It was added to support a feature deprecated in Rails 4, so you can safely remove it

--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -43,5 +43,9 @@ module Devise
           )
         end
     end
+
+    initializer "devise.deprecator" do |app|
+      app.deprecators[:devise] = Devise.deprecator if app.respond_to?(:deprecators)
+    end
   end
 end

--- a/lib/devise/test/controller_helpers.rb
+++ b/lib/devise/test/controller_helpers.rb
@@ -69,7 +69,7 @@ module Devise
           scope = resource
           resource = deprecated
 
-          ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+          Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
             [Devise] sign_in(:#{scope}, resource) on controller tests is deprecated and will be removed from Devise.
             Please use sign_in(resource, scope: :#{scope}) instead.
           DEPRECATION

--- a/lib/devise/test_helpers.rb
+++ b/lib/devise/test_helpers.rb
@@ -4,7 +4,7 @@ module Devise
   module TestHelpers
     def self.included(base)
       base.class_eval do
-        ActiveSupport::Deprecation.warn <<-DEPRECATION.strip_heredoc
+        Devise.deprecator.warn <<-DEPRECATION.strip_heredoc
           [Devise] including `Devise::TestHelpers` is deprecated and will be removed from Devise.
           For controller tests, please include `Devise::Test::ControllerHelpers` instead.
         DEPRECATION

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -108,6 +108,8 @@ class DeviseTest < ActiveSupport::TestCase
   end
 
   test 'Devise.activerecord51? deprecation' do
-    assert_deprecated { Devise.activerecord51? }
+    assert_deprecated("`Devise.activerecord51?` is deprecated and will be removed in the next major version.", Devise.deprecator) do
+      Devise.activerecord51?
+    end
   end
 end

--- a/test/models/serializable_test.rb
+++ b/test/models/serializable_test.rb
@@ -32,7 +32,9 @@ class SerializableTest < ActiveSupport::TestCase
   end
 
   test 'constant `BLACKLIST_FOR_SERIALIZATION` is deprecated' do
-    assert_deprecated { Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION }
+    assert_deprecated("Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION is deprecated! Use Devise::Models::Authenticatable::UNSAFE_ATTRIBUTES_FOR_SERIALIZATION instead.", Devise.deprecator) do
+      Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION
+    end
   end
 
   def assert_key(key, subject)


### PR DESCRIPTION
Rails 7.1 will deprecate the usage of the singleton `ActiveSupport::Deprecation` instance. This change was introduced via https://github.com/rails/rails/pull/47354. 

This pull request defines `Devise.deprecator` for the gem and uses it throughout the codebase.

Resolves https://github.com/heartcombo/devise/issues/5589
Inspired by https://github.com/rails/sprockets-rails/pull/517