### PR TITLE
Make sure Mailer defaults :from and :reply_to are handled correctly

### DIFF
--- a/test/mailers/mailer_test.rb
+++ b/test/mailers/mailer_test.rb
@@ -17,4 +17,30 @@ class MailerTest < ActionMailer::TestCase
 
     assert mail.content_transfer_encoding, "7bit"
   end
+
+  test "default values defined as proc with different arity are handled correctly" do
+    class TestMailerWithDefault < Devise::Mailer
+      default from: -> { computed_from }
+      default reply_to: ->(_) { computed_reply_to }
+
+      def confirmation_instructions(record, token, opts = {})
+        @token = token
+        devise_mail(record, :confirmation_instructions, opts)
+      end
+
+      private
+
+      def computed_from
+        "from@example.com"
+      end
+
+      def computed_reply_to
+        "reply_to@example.com"
+      end
+    end
+
+    mail = TestMailerWithDefault.confirmation_instructions(create_user, "confirmation-token")
+    assert mail.from, "from@example.com"
+    assert mail.reply_to, "reply_to@example.com"
+  end
 end


### PR DESCRIPTION
Rails allow `procs` and `lambda` with either zero or more argument as values for the different defaults. Devise however always tried to call `instance_eval` on those values, which does always pass one argument: `self`.

There was a PR to fix this specific problem in Devise https://github.com/heartcombo/devise/pull/4627, before the arity check was fixed in rails itself: https://github.com/rails/rails/pull/30391.

But even if the problem was fixed in Rails, Devise was still calling the proc/lambas with `instance_eval`. That meant the fix added to Rails did not apply to Devise.

The fix is to let Rails handle the `:from` and `:reply_to` defaults. We do that by unsetting the corresponding headers instead of duplicate the way Rails handles callables in Devise. This lets Rails handle the values when setting up the mailer.