### PR TITLE
Removed deprecations warning output for `Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
-
+* enhancements
+  * Removed deprecations warning output for `Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION` (@soartec-lab)
 
 ### 4.9.2 - 2023-04-03
 

--- a/lib/devise/models/authenticatable.rb
+++ b/lib/devise/models/authenticatable.rb
@@ -61,9 +61,6 @@ module Devise
         :last_sign_in_ip, :password_salt, :confirmation_token, :confirmed_at, :confirmation_sent_at,
         :remember_token, :unconfirmed_email, :failed_attempts, :unlock_token, :locked_at]
 
-      include Devise::DeprecatedConstantAccessor
-      deprecate_constant "BLACKLIST_FOR_SERIALIZATION", "Devise::Models::Authenticatable::UNSAFE_ATTRIBUTES_FOR_SERIALIZATION", deprecator: Devise.deprecator
-
       included do
         class_attribute :devise_modules, instance_writer: false
         self.devise_modules ||= []

--- a/test/models/serializable_test.rb
+++ b/test/models/serializable_test.rb
@@ -31,12 +31,6 @@ class SerializableTest < ActiveSupport::TestCase
     assert_key "username", @user.as_json({ only: :username, except: [:email].freeze }.freeze)["user"]
   end
 
-  test 'constant `BLACKLIST_FOR_SERIALIZATION` is deprecated' do
-    assert_deprecated("Devise::Models::Authenticatable::UNSAFE_ATTRIBUTES_FOR_SERIALIZATION", Devise.deprecator) do
-      Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION
-    end
-  end
-
   def assert_key(key, subject)
     assert subject.key?(key), "Expected #{subject.inspect} to have key #{key.inspect}"
   end


### PR DESCRIPTION
This deprecation warning worked for us, but it has served its purpose.
It was added over 2 years ago now, isn't that long enough to trigger a deprecation warning?

https://github.com/heartcombo/devise/blob/main/CHANGELOG.md#480---2021-04-29

Now that I've given it enough time, I've removed this as I think it's noise for many people who don't see `Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION`.

However, `Devise::DeprecatedConstantAccessor`, which was added in the same commit, is not referenced anywhere else, but has not been removed as it may be used in the future. Please let me know so I can delete it if necessary.

These source codes were added in the PR below:

https://github.com/heartcombo/devise/commit/0c2cab7c946e0796c673a36aebba7c0352e5fec8