### PR TITLE
`Devise::SecretKeyFinder#find` deprioritizes use of the deprecated find method in `rails`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ### Unreleased
 
 * enhancements
-  * Removed deprecations warning output for `Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION` (@soartec-lab)
+  * Removed deprecations warning output for `Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION`. (@soartec-lab)
+  * `Devise::SecretKeyFinder#find` deprioritizes use of the deprecated find method in `rails`. (@soartec-lab)
 
 ### 4.9.2 - 2023-04-03
 

--- a/lib/devise/secret_key_finder.rb
+++ b/lib/devise/secret_key_finder.rb
@@ -9,12 +9,12 @@ module Devise
     def find
       if @application.respond_to?(:credentials) && key_exists?(@application.credentials)
         @application.credentials.secret_key_base
-      elsif @application.respond_to?(:secrets) && key_exists?(@application.secrets)
-        @application.secrets.secret_key_base
       elsif @application.config.respond_to?(:secret_key_base) && key_exists?(@application.config)
         @application.config.secret_key_base
       elsif @application.respond_to?(:secret_key_base) && key_exists?(@application)
         @application.secret_key_base
+      elsif @application.respond_to?(:secrets) && key_exists?(@application.secrets)
+        @application.secrets.secret_key_base
       end
     end
 


### PR DESCRIPTION
The `rails/rails` repository has deprecated `rails.application.secrets` due to [this PR](https://github.com/rails/rails/pull/48472).

`Devise::SecretKeyFinder#find` sequentially examines the variables stored by searching `secret_key_base`, but deprecated `Rails.application.secrets` is searched first, so in many cases A warning will occur. This is noise in many cases.

```ruby
DEPRECATION WARNING: Rails.application.secrets is deprecated in favor of Rails.application.credentials and will be removed in Rails 7.2. 
```

To fix this, I changed the search order so that the deprecated `Rails.application.secrets` doesn't take precedence.