### PR TITLE
update readme file for generate devise model usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The generator will install an initializer which describes ALL of Devise's config
 In the following command you will replace `MODEL` with the class name used for the application’s users (it’s frequently `User` but could also be `Admin`). This will create a model (if one does not exist) and configure it with the default Devise modules. The generator also configures your `config/routes.rb` file to point to the Devise controller.
 
 ```console
-rails generate devise MODEL
+rails generate devise model
 ```
 
 Next, check the MODEL for any additional configuration options you might want to add, such as confirmable or lockable. If you add an option, be sure to inspect the migration file (created by the generator if your ORM supports them) and uncomment the appropriate section.  For example, if you add the confirmable option in the model, you'll need to uncomment the Confirmable section in the migration.


### PR DESCRIPTION
### env
`rails version: 6.1.6.1`
`ruby version: 2.7.4`

I tried using the readme file init, but when I do `rails generated devise MODEL`.
I get this problem
<img width="982" alt="截圖 2023-08-22 下午4 05 22" src="https://github.com/heartcombo/devise/assets/61868459/5085dd9f-7e03-4398-9bd2-e171edae8031">

so this PR is to update the README and help others not to have the same problem
