### PR TITLE
Fixed missing migration to dedicated deprecator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * enhancements
   * Removed deprecations warning output for `Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION` (@soartec-lab)
+  * Changed to use a separate deprecator inside the gem. because `rails` 7.1 will deprecate using the singleton `ActiveSupport::Deprecation.instance` (@soartec-lab, @etiennebarrie)
 
 ### 4.9.2 - 2023-04-03
 

--- a/lib/devise/rails/deprecated_constant_accessor.rb
+++ b/lib/devise/rails/deprecated_constant_accessor.rb
@@ -26,7 +26,7 @@ rescue LoadError
             super
           end
 
-          def deprecate_constant(const_name, new_constant, message: nil, deprecator: ActiveSupport::Deprecation.instance)
+          def deprecate_constant(const_name, new_constant, message: nil, deprecator: Devise.deprecator)
             class_variable_set(:@@_deprecated_constants, {}) unless class_variable_defined?(:@@_deprecated_constants)
             class_variable_get(:@@_deprecated_constants)[const_name.to_s] = { new: new_constant, message: message, deprecator: deprecator }
           end


### PR DESCRIPTION
This is a follow-up to the PR below:

- https://github.com/heartcombo/devise/pull/5583
- https://github.com/heartcombo/devise/pull/5598

`rails` has deprecated the use of `ActiveSupport::Deprecation` in singleton in [this PR](https://github.com/rails/rails/pull/47354/files), so `devise` has defined its own `Deprecator` in response to this, but there was an omission in the correction. So I fixed it.

Please note that a PR has been created that will discontinue support for EOL rails versions, and the files modified this time may also be deleted.

https://github.com/heartcombo/devise/pull/5600