### PR TITLE
Allow Devise modules to register multiple routes

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -408,22 +408,30 @@ module Devise
     NO_INPUT << strategy if options[:no_input]
 
     if route = options[:route]
+      routes = {}
+
       case route
       when TrueClass
-        key, value = module_name, []
+        routes[module_name] = []
       when Symbol
-        key, value = route, []
+        routes[route] = []
       when Hash
-        key, value = route.keys.first, route.values.flatten
+        routes = route
       else
         raise ArgumentError, ":route should be true, a Symbol or a Hash"
       end
 
-      URL_HELPERS[key] ||= []
-      URL_HELPERS[key].concat(value)
-      URL_HELPERS[key].uniq!
+      routes.each do |key, value|
+        URL_HELPERS[key] ||= []
+        URL_HELPERS[key].concat(value)
+        URL_HELPERS[key].uniq!
 
-      ROUTES[module_name] = key
+        ROUTES[module_name] = key
+      end
+
+      if routes.size > 1
+        ROUTES[module_name] = routes.keys
+      end
     end
 
     if options[:model]

--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -92,7 +92,7 @@ module Devise
     end
 
     def routes
-      @routes ||= ROUTES.values_at(*self.modules).compact.uniq
+      @routes ||= ROUTES.values_at(*self.modules).compact.flatten.uniq
     end
 
     def authenticatable?

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -84,6 +84,21 @@ class DeviseTest < ActiveSupport::TestCase
     assert_equal :fruits, Devise::CONTROLLERS[:kivi]
     Devise::ALL.delete(:kivi)
     Devise::CONTROLLERS.delete(:kivi)
+
+    Devise.add_module(:apple, route: true)
+    assert_equal :apple, Devise::ROUTES[:apple]
+    Devise::ALL.delete(:apple)
+    Devise::ROUTES.delete(:apple)
+
+    Devise.add_module(:pineapple, route: { session: [nil, :new] })
+    assert_equal :session, Devise::ROUTES[:pineapple]
+    Devise::ALL.delete(:pineapple)
+    Devise::ROUTES.delete(:pineapple)
+
+    Devise.add_module(:mango, route: { checkout: [nil, :show], session: [nil, :new] })
+    assert_equal [:checkout, :session], Devise::ROUTES[:mango]
+    Devise::ALL.delete(:mango)
+    Devise::ROUTES.delete(:mango)
   end
 
   test 'should complain when comparing empty or different sized passes' do


### PR DESCRIPTION
This change was precipitated by https://github.com/abevoelker/devise-passwordless, a Devise extension which adds a `:magic_link_authenticatable` strategy which enables registration and sign-in via emailed magic links.

This change is needed we can register both a `:magic_link` and a `:session` route and controllers, because we need to both provide a custom sessions controller as well as handle magic links. We are currently monkey patching this logic in and it works great - `Devise.add_module` continues to work exactly the same for modules with singular routes.