### PR TITLE
Add support for namespaced Devise models in views path

### DIFF
--- a/lib/generators/devise/devise_generator.rb
+++ b/lib/generators/devise/devise_generator.rb
@@ -19,7 +19,7 @@ module Devise
 
       def add_devise_routes
         devise_route  = "devise_for :#{plural_name}".dup
-        devise_route << %Q(, class_name: "#{class_name}") if class_name.include?("::")
+        devise_route << %Q(, class_name: "#{class_name}", as: "#{class_name.deconstantize.underscore}") if class_name.include?("::")
         devise_route << %Q(, skip: :all) unless options.routes?
         route devise_route
       end


### PR DESCRIPTION
This commit modifies the `add_devise_routes` method to handle namespaced Devise models correctly. When the `class_name` includes a namespace (i.e., contains "::"), the namespace is used as the `as` option value for the `devise_for` route helper. This ensures that Devise looks for views in the correct directory corresponding to the namespace of the model.
https://github.com/heartcombo/devise/blob/f6e73e5b5c8f519f4be29ac9069c6ed8a2343ce4/lib/devise/mapping.rb#L55