### PR TITLE
Replace [data-turbo-cache=false] with [data-turbo-temporary]

### DIFF
--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
+  <div id="error_explanation" data-turbo-temporary>
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,


### PR DESCRIPTION
Following the suggestion from issue https://github.com/heartcombo/devise/issues/5662

The turbo drive's attribute `[data-turbo-cache=false]` was deprecated in favor of `data-turbo-temporary`