### PR TITLE
Adds Ruby 3.3 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
           - gemfiles/Gemfile-rails-6-1
           - gemfiles/Gemfile-rails-6-0
         ruby:
+          - '3.3'
           - '3.2'
           - '3.1'
           - '3.0'
@@ -20,6 +21,10 @@ jobs:
           - DEVISE_ORM=active_record
           - DEVISE_ORM=mongoid
         exclude:
+          - gemfile: gemfiles/Gemfile-rails-main
+            ruby: '2.7' # Rails > 7.1 supports Ruby >= 3.1
+          - gemfile: gemfiles/Gemfile-rails-main
+            ruby: '3.0' # Rails > 7.1 supports Ruby >= 3.1
           - gemfile: Gemfile
             env: DEVISE_ORM=mongoid
           - gemfile: gemfiles/Gemfile-rails-main


### PR DESCRIPTION
This PR adds Ruby 3.3 in the CI matrix.

It excludes rubies that are incompatible with Rails 7.2

```
Because every version of rails depends on Ruby >= 3.1.0
  and Gemfile-rails-main depends on rails >= 0,
  Ruby >= 3.1.0 is required.
  ```