### PR TITLE
Simplify SecretKeyFinder

### DIFF
--- a/lib/devise/secret_key_finder.rb
+++ b/lib/devise/secret_key_finder.rb
@@ -7,15 +7,7 @@ module Devise
     end
 
     def find
-      if @application.respond_to?(:credentials) && key_exists?(@application.credentials)
-        @application.credentials.secret_key_base
-      elsif @application.respond_to?(:secrets) && key_exists?(@application.secrets)
-        @application.secrets.secret_key_base
-      elsif @application.config.respond_to?(:secret_key_base) && key_exists?(@application.config)
-        @application.config.secret_key_base
-      elsif @application.respond_to?(:secret_key_base) && key_exists?(@application)
-        @application.secret_key_base
-      end
+      @application.secret_key_base
     end
 
     private


### PR DESCRIPTION
Rails back to 6.0 has Rails.application.secret_key_base.  We don't need all these conditionals anymore.