### PR TITLE
Update default password_length to be 8 minimum

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -119,7 +119,7 @@ module Devise
 
   # Range validation for password length
   mattr_accessor :password_length
-  @@password_length = 6..128
+  @@password_length = 8..128
 
   # The time the user will be remembered without asking for credentials again.
   mattr_accessor :remember_for

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -12,7 +12,7 @@ module Devise
     # Validatable adds the following options to +devise+:
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
-    #   * +password_length+: a range expressing password length. Defaults to 6..128.
+    #   * +password_length+: a range expressing password length. Defaults to 8..128.
     #
     module Validatable
       # All validations used by this module.

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -80,10 +80,10 @@ class ValidatableTest < ActiveSupport::TestCase
     assert user.errors.added?(:password_confirmation, :confirmation, attribute: "Password")
   end
 
-  test 'should require a password with minimum of 7 characters' do
-    user = new_user(password: '12345', password_confirmation: '12345')
+  test 'should require a password with minimum of 8 characters' do
+    user = new_user(password: '1234567', password_confirmation: '1234567')
     assert user.invalid?
-    assert_equal 'is too short (minimum is 7 characters)', user.errors[:password].join
+    assert_equal 'is too short (minimum is 8 characters)', user.errors[:password].join
   end
 
   test 'should require a password with maximum of 72 characters long' do

--- a/test/rails_app/lib/shared_user.rb
+++ b/test/rails_app/lib/shared_user.rb
@@ -6,7 +6,7 @@ module SharedUser
   included do
     devise :database_authenticatable, :confirmable, :lockable, :recoverable,
            :registerable, :rememberable, :timeoutable,
-           :trackable, :validatable, :omniauthable, password_length: 7..72,
+           :trackable, :validatable, :omniauthable, password_length: 8..72,
            reconfirmable: false
 
     attr_accessor :other_key


### PR DESCRIPTION
OWASP recommends a password length of at least 8 characters
https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls

Partly addresses https://github.com/heartcombo/devise/issues/5591