### PR TITLE
Add ignore_period option to .confirm

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -73,12 +73,16 @@ module Devise
         required_methods
       end
 
-      # Confirm a user by setting it's confirmed_at to actual time. If the user
-      # is already confirmed, add an error to email field. If the user is invalid
-      # add errors
+      # Confirm a user by setting its confirmed_at to the current time. If the user
+      # is already confirmed, add an error to email field.
+      #
+      # Supported options:
+      # * `:ensure_valid` - When true, validations are run when saving the record (otherwise, validations are only run
+      #   on reconfirmation, to ensure e-mail uniqueness).
+      # * `:ignore_period` - When true, skips checking whether the confirmation period is expired.
       def confirm(args = {})
         pending_any_confirmation do
-          if confirmation_period_expired?
+          if !args[:ignore_period] && confirmation_period_expired?
             self.errors.add(:email, :confirmation_period_expired,
               period: Devise::TimeInflector.time_ago_in_words(self.class.confirm_within.ago))
             return false

--- a/test/models/confirmable_test.rb
+++ b/test/models/confirmable_test.rb
@@ -387,6 +387,18 @@ class ConfirmableTest < ActiveSupport::TestCase
     admin.stubs(:valid?).returns(false)
     assert_not admin.confirm(ensure_valid: true)
   end
+
+  test 'should ignore the confirmation period when ignore_period is true' do
+    swap Devise, confirm_within: 3.days do
+      user = Timecop.freeze(4.days.ago) do
+        create_user
+      end
+      assert_not user.confirm
+      assert_not user.confirmed?
+      assert user.confirm(ignore_period: true)
+      assert user.confirmed?
+    end
+  end
 end
 
 class ReconfirmableTest < ActiveSupport::TestCase


### PR DESCRIPTION
Hi and thank you for all your work, I've been using Devise in all my projects since forever, but this is my first contribution.

In most if not all projects, I end up needing this for an admin panel or backoffice, where an admin can mark an email as confirmed manually. Calling `.confirm` will not work if the period is expired. I know it is possible to resend the confirmation link and so reset the period, but for some reason or other, this is a flow support teams end up needing. It's very easy to implement of course, but I think it'd be nice to have it in the library, instead of going to the database behind the library's back.