### PR TITLE
Use locales on mailer views

### DIFF
--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t('.welcome', email: @email) %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t('.description') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('.button'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @email %>!</p>
+<p><%= t('.hello', email: @email) %></p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+  <p><%= t('.unconfirmed_description', email: @resource.unconfirmed_email) %></p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+  <p><%= t('.confirmed_description', email: @resource.email) %></p>
 <% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,3 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.hello', email: @resource.email) %></p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p><%= t('.description') %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.hello', email: @resource.email) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t('.description') %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t('.button'), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t('.please_ignore') %></p>
+<p><%= t('.password_wont_change') %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t('.hello', email: @resource.email) %></p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+<p><%= t('.description') %></p>
 
-<p>Click the link below to unlock your account:</p>
+<p><%= t('.unlock_description') %></p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>
+<p><%= link_to t('.button'), unlock_url(@resource, unlock_token: @token) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,14 +19,31 @@ en:
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"
+        welcome: "Welcome %{email}!"
+        description: "You can confirm your account email through the link below:"
+        button: "Confirm my account"
       reset_password_instructions:
         subject: "Reset password instructions"
+        hello: "Hello %{email}!"
+        description: "Someone has requested a link to change your password. You can do this through the link below."
+        button: "Change my password"
+        please_ignore: "If you didn't request this, please ignore this email."
+        password_wont_change: "Your password won't change until you access the link above and create a new one."
       unlock_instructions:
         subject: "Unlock instructions"
+        hello: "Hello %{email}!"
+        description: "Your account has been locked due to an excessive number of unsuccessful sign in attempts."
+        unlock_description: "Click the link below to unlock your account:"
+        button: "Unlock my account"
       email_changed:
         subject: "Email Changed"
+        hello: "Hello %{email}!"
+        unconfirmed_description: "We're contacting you to notify you that your email is being changed to %{email}."
+        confirmed_description: "We're contacting you to notify you that your email has been changed to %{email}."
       password_change:
         subject: "Password Changed"
+        hello: "Hello %{email}!"
+        description: "We're contacting you to notify you that your password has been changed."
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."


### PR DESCRIPTION
The other day I was trying to internationalize mailers on my application. I ended up copying the views to translate the mail content, which could be done by changing the content in the local (en.yml)file.

So, that is why I think it would be nice to have the I18n keys instead of the plain text in the mailers