### PR TITLE
Adds an option to strictly enforce single recipients for emails

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -308,6 +308,17 @@ module Devise
   mattr_accessor :sign_in_after_change_password
   @@sign_in_after_change_password = true
 
+  # When sending an email to an action set below, raise an error if
+  # there is more than one recipient. For example:
+  #   @@strict_single_recipient_emails = [
+  #     :confirmation_instructions,
+  #     :reset_password_instructions,
+  #     :unlock_instructions
+  #   ]
+  # By default any action can be sent to multiple recipients.
+  mattr_accessor :strict_single_recipient_emails
+  @@strict_single_recipient_emails = []
+
   # Default way to set up Devise. Run rails generate devise_install to create
   # a fresh initializer with all configuration values.
   def self.setup

--- a/test/controllers/internal_helpers_test.rb
+++ b/test/controllers/internal_helpers_test.rb
@@ -5,7 +5,7 @@ require 'test_helper'
 class MyController < DeviseController
 end
 
-class HelpersTest < Devise::ControllerTestCase
+class InternalHelpersTest < Devise::ControllerTestCase
   tests MyController
 
   def setup

--- a/test/devise_test.rb
+++ b/test/devise_test.rb
@@ -97,7 +97,7 @@ class DeviseTest < ActiveSupport::TestCase
 
   test 'Devise.email_regexp should match valid email addresses' do
     valid_emails = ["test@example.com", "jo@jo.co", "f4$_m@you.com", "testing.example@example.com.ua", "test@tt", "test@valid---domain.com"]
-    non_valid_emails = ["rex", "test user@example.com", "test_user@example server.com"]
+    non_valid_emails = ["rex", "test user@example.com", "test_user@example server.com", "test_user@example,rex@server.com", "test_user@example;rex@server.com"]
 
     valid_emails.each do |email|
       assert_match Devise.email_regexp, email

--- a/test/mailers/helpers/helpers_test.rb
+++ b/test/mailers/helpers/helpers_test.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class HelpersTest < ActiveSupport::TestCase
+  def setup
+    Devise.strict_single_recipient_emails = []
+  end
+
+  def user
+    @user ||= create_user
+  end
+
+  def send_mail(opts={})
+    Devise.mailer.reset_password_instructions(
+      user,
+      'fake-token',
+      opts,
+    ).deliver
+  end
+
+  test "an email passed in opts is used instead of the record's email" do
+    mail = send_mail({to: "test2@example.com"})
+
+    assert_equal ["test2@example.com"], mail.to
+  end
+
+  test "multiple recipients are permitted when setting configured to empty array" do
+    mail = send_mail({
+      to: ["test1@example.com", "test2@example.com"],
+      bcc: ["admin@example.com"]
+    })
+
+    assert_equal ["test1@example.com", "test2@example.com"], mail.to
+    assert_equal ["admin@example.com"], mail.bcc
+  end
+
+  test "multiple recipients are permitted setting configured to another action" do
+    Devise.strict_single_recipient_emails = [:unlock_instructions]
+    mail = send_mail({
+      to: ["test1@example.com", "test2@example.com"],
+      bcc: ["admin@example.com"]
+    })
+
+    assert_equal ["test1@example.com", "test2@example.com"], mail.to
+    assert_equal ["admin@example.com"], mail.bcc
+  end
+
+  test "single to recipient does not raises an error when action has strict enforcement" do
+    Devise.strict_single_recipient_emails = [:reset_password_instructions]
+    mail = send_mail
+
+    assert_equal [user.email], mail.to
+  end
+
+  test "multiple to recipients raises an error when action has strict enforcement" do
+
+    Devise.strict_single_recipient_emails = [:reset_password_instructions]
+
+    [
+      { to: 'test1@example.com', 'to' => 'test2@example.com' },
+      { to: 'test1@example.com,test2@example.com' },
+      { to: 'test1@example.com;test2@example.com' },
+      { to: ['test1@example.com', 'test2@example.com'] }
+    ].each do |headers|
+      assert_raises(Devise::Mailers::Helpers::MultipleRecipientsError) do
+        send_mail(headers)
+      end
+    end
+  end
+
+  test "bcc raises an error when action has strict enforcement" do
+    Devise.strict_single_recipient_emails = [:reset_password_instructions]
+    assert_raises(Devise::Mailers::Helpers::MultipleRecipientsError) do
+      send_mail({bcc: ["admin@example.com"]})
+    end
+  end
+
+  test "cc raises an error when action has strict enforcement" do
+    Devise.strict_single_recipient_emails = [:reset_password_instructions]
+    assert_raises(Devise::Mailers::Helpers::MultipleRecipientsError) do
+      send_mail({cc: ["admin@example.com"]})
+    end
+  end
+
+end


### PR DESCRIPTION
Devise sends email containing sensitive values such as confirmation URLs, password reset URLs, and unlock URLs. In most (all?) cases, these should only be sent to a single person so that they alone can click the link. If the email is sent to multiple addresses, another person could click the link.

Set `Devise.strict_single_recipient_emails` to an array of actions to raise an error when the email would be sent to more than one email address.

By default Devise is secure:

- `Devise.email_regexp` will reject email addresses containing separators (`,;`)
- Devise gets a single email address from `record.email`

However, when using `opts`, and particularly if providing untrusted user input to `opts`, multiple values could be present in `to:`, `cc:`, or `bcc:`.

Example:

```ruby
# POST https://your-app.com/customised-reset-password?email[]="attacker@example.com"&email[]="victim@example.com"

# Returns the victim's user
user = User.find_by(email: params[:email])

# unsafe, will send the link to two addresses: 
Devise.mailer.reset_password_instructions(user, 'fake-token', {to: params[:email]})

# safe, devise will use the user's email address
Devise.reset_password_instructions(user, 'fake-token')

# safe, will raise error:
Devise.strict_single_recipient_emails = [
  :confirmation_instructions,
  :reset_password_instructions,
  :unlock_instructions
]
Devise.mailer.reset_password_instructions(user, 'fake-token', {to: params[:email]})
```

---

This work is similar to what I introduced at GitLab, but disabled by default and more configurable:

a) to avoid breaking changes,
b) to make it easier to enable for a subset of actions

GitLab MR: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/145753

This is my first contribution to Devise - very happy to receive feedback and change things up as needed ❤️  Also fine if you'd rather not include this change 👍 