### PR TITLE
Rails 8: Make test helpers work with deferred routes

### DIFF
--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -33,7 +33,9 @@ module Devise
     # Receives an object and finds a scope for it. If a scope cannot be found,
     # raises an error. If a symbol is given, it's considered to be the scope.
     def self.find_scope!(obj)
+      Rails.application.routes_reloader.try(:execute_unless_loaded)
       obj = obj.devise_scope if obj.respond_to?(:devise_scope)
+
       case obj
       when String, Symbol
         return obj.to_sym


### PR DESCRIPTION
Fixes https://github.com/heartcombo/devise/issues/5705.

Notes:
- The `sign_in` and `sign_out` controller and integration test helpers all call `Devise::Mapping.find_scope!`, so that method seemed like a good place to lazy load routes if they were not already loaded.
- Used `try` to keep backwards compatibility since `reload_routes_unless_loaded` only exists in Rails 8.