### PR TITLE
Rails 8: Update route registration to use keyword arguments

### DIFF
--- a/lib/devise/rails/routes.rb
+++ b/lib/devise/rails/routes.rb
@@ -413,7 +413,7 @@ module ActionDispatch::Routing
           controller: controllers[:registrations]
         }
 
-        resource :registration, options do
+        resource :registration, **options do
           get :cancel
         end
       end


### PR DESCRIPTION
Running devise against the main branch of rails I get the following error:
```
ArgumentError:
'{:only=>[:new, :create, :edit, :update, :destroy], :path=>"", :path_names=>{:new=>"sign_up", :edit=>"edit", :cancel=>"cancel"}, :controller=>"devise/registrations"}s' is not a supported controller name. This can lead to potential routing problems. See [https://guides.rubyonrails.org/routing.html#specifying-a-controller-to-use](https://guides.rubyonrails.org/routing.html#specifying-a-controller-to-use)
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:313:in 'block (2 levels) in ActionDispatch::Routing::Mapper::Mapping#check_controller_and_action'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:350:in 'ActionDispatch::Routing::Mapper::Mapping#translate_controller'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:309:in 'block in ActionDispatch::Routing::Mapper::Mapping#check_controller_and_action'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:324:in 'ActionDispatch::Routing::Mapper::Mapping#check_part'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:308:in 'ActionDispatch::Routing::Mapper::Mapping#check_controller_and_action'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:249:in 'ActionDispatch::Routing::Mapper::Mapping#normalize_options!'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:146:in 'ActionDispatch::Routing::Mapper::Mapping#initialize'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:99:in 'Class#new'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:99:in 'ActionDispatch::Routing::Mapper::Mapping.build'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:2047:in 'ActionDispatch::Routing::Mapper::Resources#add_route'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:2024:in 'ActionDispatch::Routing::Mapper::Resources#decomposed_match'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:2022:in 'block in ActionDispatch::Routing::Mapper::Resources#decomposed_match'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1960:in 'ActionDispatch::Routing::Mapper::Resources#path_scope'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1588:in 'block in ActionDispatch::Routing::Mapper::Resources#member'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1839:in 'ActionDispatch::Routing::Mapper::Resources#with_scope_level'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1582:in 'ActionDispatch::Routing::Mapper::Resources#member'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:2022:in 'ActionDispatch::Routing::Mapper::Resources#decomposed_match'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1993:in 'ActionDispatch::Routing::Mapper::Resources#map_match'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1736:in 'block in ActionDispatch::Routing::Mapper::Resources#match'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1732:in 'ActionDispatch::Routing::Mapper::Resources#match'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:741:in 'ActionDispatch::Routing::Mapper::HttpHelpers#get'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:417:in 'block in ActionDispatch::Routing::Mapper#devise_registration'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1357:in 'block (2 levels) in ActionDispatch::Routing::Mapper::Resources#resource'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:945:in 'ActionDispatch::Routing::Mapper::Scoping#controller'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1847:in 'ActionDispatch::Routing::Mapper::Resources#resource_scope'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1356:in 'block in ActionDispatch::Routing::Mapper::Resources#resource'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1839:in 'ActionDispatch::Routing::Mapper::Resources#with_scope_level'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1354:in 'ActionDispatch::Routing::Mapper::Resources#resource'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1781:in 'Kernel#public_send'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1781:in 'block in ActionDispatch::Routing::Mapper::Resources#apply_common_behavior_for'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1781:in 'ActionDispatch::Routing::Mapper::Resources#apply_common_behavior_for'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1350:in 'ActionDispatch::Routing::Mapper::Resources#resource'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:416:in 'ActionDispatch::Routing::Mapper#devise_registration'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:268:in 'block (4 levels) in ActionDispatch::Routing::Mapper#devise_for'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:268:in 'block (3 levels) in ActionDispatch::Routing::Mapper#devise_for'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:472:in 'ActionDispatch::Routing::Mapper#with_devise_exclusive_scope'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:267:in 'block (2 levels) in ActionDispatch::Routing::Mapper#devise_for'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:370:in 'block in ActionDispatch::Routing::Mapper#devise_scope'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:930:in 'ActionDispatch::Routing::Mapper::Scoping#scope'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/mapper.rb:1060:in 'ActionDispatch::Routing::Mapper::Scoping#constraints'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:369:in 'ActionDispatch::Routing::Mapper#devise_scope'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:266:in 'block in ActionDispatch::Routing::Mapper#devise_for'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails/routes.rb:242:in 'ActionDispatch::Routing::Mapper#devise_for'
# ./config/routes.rb:2:in 'block in <main>'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/route_set.rb:479:in 'BasicObject#instance_exec'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/route_set.rb:479:in 'ActionDispatch::Routing::RouteSet#eval_block'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/actionpack/lib/action_dispatch/routing/route_set.rb:461:in 'ActionDispatch::Routing::RouteSet#draw'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/engine/lazy_route_set.rb:73:in 'Rails::Engine::LazyRouteSet#draw'
# ./config/routes.rb:1:in '<main>'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/application/routes_reloader.rb:60:in 'Kernel#load'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/application/routes_reloader.rb:60:in 'block in Rails::Application::RoutesReloader#load_paths'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/application/routes_reloader.rb:60:in 'Rails::Application::RoutesReloader#load_paths'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/application/routes_reloader.rb:26:in 'Rails::Application::RoutesReloader#reload!'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/application.rb:161:in 'Rails::Application#reload_routes!'
# /usr/local/bundle/bundler/gems/devise-a259ff3c2891/lib/devise/rails.rb:17:in 'block in <class:Engine>'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/activesupport/lib/active_support/lazy_load_hooks.rb:94:in 'block in ActiveSupport::LazyLoadHooks#execute_hook'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/activesupport/lib/active_support/lazy_load_hooks.rb:87:in 'ActiveSupport::LazyLoadHooks#with_execution_control'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/activesupport/lib/active_support/lazy_load_hooks.rb:92:in 'ActiveSupport::LazyLoadHooks#execute_hook'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/activesupport/lib/active_support/lazy_load_hooks.rb:78:in 'block in ActiveSupport::LazyLoadHooks#run_load_hooks'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/activesupport/lib/active_support/lazy_load_hooks.rb:77:in 'ActiveSupport::LazyLoadHooks#run_load_hooks'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/application/finisher.rb:79:in 'block in <module:Finisher>'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/initializable.rb:32:in 'BasicObject#instance_exec'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/initializable.rb:32:in 'Rails::Initializable::Initializer#run'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/initializable.rb:61:in 'block in Rails::Initializable#run_initializers'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/initializable.rb:60:in 'Rails::Initializable#run_initializers'
# /usr/local/bundle/bundler/gems/rails-cc2c43b8608e/railties/lib/rails/application.rb:440:in 'Rails::Application#initialize!'
# ./config/environment.rb:5:in '<top (required)>'
# ./spec/rails_helper.rb:4:in 'Kernel#require_relative'
# ./spec/rails_helper.rb:4:in '<top (required)>'
# ./spec/models/user_spec.rb:22:in '<top (required)>'

No examples found.
```

It looks like it's been caused by this PR getting merged: https://github.com/rails/rails/pull/52605

After updating this call to use keyword arguments, the error doesn't happen any more