### PR TITLE
Rails 8: Fix CI sqlite3 error for Gemfile-rails-main

### DIFF
--- a/gemfiles/Gemfile-rails-main
+++ b/gemfiles/Gemfile-rails-main
@@ -21,5 +21,5 @@ group :test do
 end
 
 platforms :ruby do
-  gem "sqlite3", "~> 1.4"
+  gem "sqlite3", "~> 2.0"
 end


### PR DESCRIPTION
Fixes the following CI failures that were triggered by https://github.com/heartcombo/devise/pull/5706:

- https://github.com/heartcombo/devise/actions/runs/10418314232/job/28889211134?pr=5706
- https://github.com/heartcombo/devise/actions/runs/10418314232/job/28889211187?pr=5706
- https://github.com/heartcombo/devise/actions/runs/10418314232/job/28889211219?pr=5706

The errors happen because Rails 8 now requires sqlite gem >= 2.0 after this commit was merged: https://github.com/rails/rails/pull/51958.