### PR TITLE
Fix bugs in `extend_remember_period` (reprise)

### DIFF
--- a/lib/devise/hooks/rememberable.rb
+++ b/lib/devise/hooks/rememberable.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
+# This hook runs when a user logs in, if they set the `remember_me` param (eg. from a checkbox in the UI).
 Warden::Manager.after_set_user except: :fetch do |record, warden, options|
   scope = options[:scope]
   if record.respond_to?(:remember_me) && options[:store] != false &&
      record.remember_me && warden.authenticated?(scope)
+
     Devise::Hooks::Proxy.new(warden).remember_me(record)
+  end
+end
+
+# This hook runs when we retrieve a user from the session. If the user's remember session should be extended
+# we do it here.
+Warden::Manager.after_set_user only: :fetch do |record, warden, options|
+  if record.respond_to?(:extend_remember_me?) && record.extend_remember_me? &&
+      options[:store] != false && warden.authenticated?(options[:scope])
+
+    proxy = Devise::Hooks::Proxy.new(warden)
+    proxy.remember_me(record) if proxy.remember_me_is_active?(record)
   end
 end

--- a/lib/devise/models/rememberable.rb
+++ b/lib/devise/models/rememberable.rb
@@ -70,6 +70,10 @@ module Devise
         self.class.extend_remember_period
       end
 
+      def extend_remember_me?
+        !!self.class.extend_remember_period
+      end
+
       def rememberable_value
         if respond_to?(:remember_token)
           remember_token

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -169,7 +169,12 @@ Devise.setup do |config|
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
 
-  # If true, extends the user's remember period when remembered via cookie.
+  # If true, extends the user's remember period every time the user makes a request.
+  # As long as the user accesses the site once every `config.remember_for`, they can
+  # stay logged in forever.
+  # If false, how long the user will be remembered for is set on initial login,
+  # and only when the user starts a new session. So users will need to log in
+  # again every `config.remember_for`.
   # config.extend_remember_period = false
 
   # Options to be passed to the created cookie. For instance, you can set


### PR DESCRIPTION
close #5351, #5418, https://github.com/heartcombo/devise/issues/5701

This pull request contains the same changes as https://github.com/heartcombo/devise/pull/5418. However, since PR #5418 was created three years ago, it needed conflict resolution. While I could have asked @nomis to resolve the conflicts, I decided to create a new PR myself since it was just a matter of resolving those conflicts. With this fix, extend_remember_period now works as expected on my end.