### PR TITLE
Fix: email format

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -115,7 +115,8 @@ module Devise
   # @ symbols or whitespaces in either the localpart or the domain, and that
   # there is a single @ symbol separating the localpart and the domain.
   mattr_accessor :email_regexp
-  @@email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  @@email_regexp = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/
+
 
   # Range validation for password length
   mattr_accessor :password_length

--- a/test/models/authenticatable_test.rb
+++ b/test/models/authenticatable_test.rb
@@ -18,6 +18,7 @@ class AuthenticatableTest < ActiveSupport::TestCase
   # config.strip_whitespace_keys = [:email]
   test 'find_or_initialize_with_errors uses parameter filter on find' do
     user = User.create!(email: "example@example.com", password: "1234567")
+
     assert_equal user, User.find_or_initialize_with_errors([:email], { email: " EXAMPLE@example.com " })
   end
 


### PR DESCRIPTION
Problem: You can register an invalid email: john.doe@gmail
Fix: Regular expresion
# devise.rb
@@email_regexp = /\A[^@\s]+@[^@\s]+\.[^@\s]+\z/