### PR TITLE
[Docs]Remove unnecessary closing parenthesis in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ If the customization at the views level is not enough, you can customize each co
       ...
     end
     ```
-    Use the `-c` flag to specify one or more controllers, for example: `rails generate devise:controllers users -c sessions`)
+    Use the `-c` flag to specify one or more controllers, for example: `rails generate devise:controllers users -c sessions`
 
 2. Tell the router to use this controller:
 


### PR DESCRIPTION
Fixed a typo in the README where an extra closing parenthesis was present in the example command for generating Devise controllers using the -c flag.