### PR TITLE
Introduce config to allow for password complexity

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,6 @@ en:
         other: "%{count} errors prohibited this %{resource} from being saved:"
       must_contain_lowercase: "must include at least one lowercase letter"
       must_contain_uppercase: "must include at least one uppercase letter"
-      must_contain_number: "must include at least one number"
+      must_contain_digit: "must include at least one number"
       must_contain_special_character: "must include at least one special character"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -63,3 +63,8 @@ en:
       not_saved:
         one: "1 error prohibited this %{resource} from being saved:"
         other: "%{count} errors prohibited this %{resource} from being saved:"
+      must_contain_lowercase: "must include at least one lowercase letter"
+      must_contain_uppercase: "must include at least one uppercase letter"
+      must_contain_number: "must include at least one number"
+      must_contain_special_character: "must include at least one special character"
+

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -120,6 +120,26 @@ module Devise
   mattr_accessor :password_length
   @@password_length = 6..128
 
+  # Validate presence of lower case letter in password
+  mattr_accessor :password_requires_lowercase
+  @@password_requires_lowercase = false
+
+  # Validate presence of upper case letter in password
+  mattr_accessor :password_requires_uppercase
+  @@password_requires_uppercase = false
+
+  # Validate presence of special character in password
+  mattr_accessor :password_requires_special_character
+  @@password_requires_special_character = false
+
+  # Special character options
+  mattr_accessor :password_special_characters
+  @@password_special_characters = "!?@#$%^&*()_+-=[]{}|:;<>,./"
+
+  # Validate presence of a number in password
+  mattr_accessor :password_requires_number
+  @@password_requires_number = false
+
   # The time the user will be remembered without asking for credentials again.
   mattr_accessor :remember_for
   @@remember_for = 2.weeks

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -120,25 +120,15 @@ module Devise
   mattr_accessor :password_length
   @@password_length = 6..128
 
-  # Validate presence of lower case letter in password
-  mattr_accessor :password_requires_lowercase
-  @@password_requires_lowercase = false
-
-  # Validate presence of upper case letter in password
-  mattr_accessor :password_requires_uppercase
-  @@password_requires_uppercase = false
-
-  # Validate presence of special character in password
-  mattr_accessor :password_requires_special_character
-  @@password_requires_special_character = false
-
-  # Special character options
-  mattr_accessor :password_special_characters
-  @@password_special_characters = "!?@#$%^&*()_+-=[]{}|:;<>,./"
-
-  # Validate presence of a number in password
-  mattr_accessor :password_requires_number
-  @@password_requires_number = false
+  # Password complexity configuration
+  mattr_accessor :password_complexity
+  @@password_complexity = {
+    require_upper: false,    
+    require_lower: false,    
+    require_digit: false,   
+    require_special: false,  
+    special_characters: "!?@#$%^&*()_+-=[]{}|:;<>,./"
+  }
 
   # The time the user will be remembered without asking for credentials again.
   mattr_accessor :remember_for

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -13,11 +13,16 @@ module Devise
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
     #   * +password_length+: a range expressing password length. Defaults to 6..128.
-    #
+    #   * +password_requires_lowercase+: a boolean to require a lower case letter in the password. Defaults to false.
+    #   * +password_requires_uppercase+: a boolean to require an upper case letter in the password. Defaults to false.
+    #   * +password_requires_special_character+: a boolean to require a special character in the password. Defaults to false.
+    #   * +password_requires_number+: a boolean to require a number in the password. Defaults to false.
+    #   * +password_special_characters+: a string with the special characters that are allowed in the password. Defaults to nil.
+    
     module Validatable
       # All validations used by this module.
       VALIDATIONS = [:validates_presence_of, :validates_uniqueness_of, :validates_format_of,
-                     :validates_confirmation_of, :validates_length_of].freeze
+                     :validates_confirmation_of, :validates_length_of, :validate].freeze
 
       def self.required_fields(klass)
         []
@@ -35,6 +40,13 @@ module Devise
           validates_presence_of     :password, if: :password_required?
           validates_confirmation_of :password, if: :password_required?
           validates_length_of       :password, within: password_length, allow_blank: true
+
+          validates_format_of :password, with: /\p{Lower}/, if: -> { password_requires_lowercase }, message: :must_contain_lowercase
+          validates_format_of :password, with: /\p{Upper}/, if: -> { password_requires_uppercase }, message: :must_contain_uppercase
+          validates_format_of :password, with: /\d/, if: -> { password_requires_number }, message: :must_contain_number
+
+          # Run as special character check as a custom validation to ensure password_special_characters is evaluated at runtime
+          validate :password_must_contain_special_character, if: -> { password_requires_special_character }
         end
       end
 
@@ -60,8 +72,47 @@ module Devise
         true
       end
 
+      # Make these instance methods so the default Devise.password_requires_<> 
+      #can be overridden
+      def password_requires_lowercase
+        self.class.password_requires_lowercase
+      end
+
+      def password_requires_uppercase
+        self.class.password_requires_uppercase
+      end
+      
+      def password_requires_number
+        self.class.password_requires_number 
+      end
+      
+      def password_requires_special_character
+        self.class.password_requires_special_character
+      end
+
+      def password_special_characters
+        self.class.password_special_characters
+      end
+
+      def password_must_contain_special_character
+        special_character_regex = /[#{Regexp.escape(password_special_characters)}]/
+      
+        unless password =~ special_character_regex
+          errors.add(:password, :must_contain_special_character)
+        end
+      end
+      
       module ClassMethods
-        Devise::Models.config(self, :email_regexp, :password_length)
+        Devise::Models.config(
+          self,
+          :email_regexp,
+          :password_length,
+          :password_requires_lowercase,
+          :password_requires_uppercase,
+          :password_requires_special_character,
+          :password_requires_number,
+          :password_special_characters
+        )
       end
     end
   end

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -16,7 +16,7 @@ module Devise
     #   * +password_requires_lowercase+: a boolean to require a lower case letter in the password. Defaults to false.
     #   * +password_requires_uppercase+: a boolean to require an upper case letter in the password. Defaults to false.
     #   * +password_requires_special_character+: a boolean to require a special character in the password. Defaults to false.
-    #   * +password_requires_number+: a boolean to require a number in the password. Defaults to false.
+    #   * +password_requires_digit+: a boolean to require a digit in the password. Defaults to false.
     #   * +password_special_characters+: a string with the special characters that are allowed in the password. Defaults to nil.
     #
     # Since +password_length+ is applied in a proc within `validates_length_of` it can be overridden
@@ -45,7 +45,7 @@ module Devise
 
           validates_format_of :password, with: /\p{Lower}/, if: -> { password_requires_lowercase }, message: :must_contain_lowercase
           validates_format_of :password, with: /\p{Upper}/, if: -> { password_requires_uppercase }, message: :must_contain_uppercase
-          validates_format_of :password, with: /\d/, if: -> { password_requires_number }, message: :must_contain_number
+          validates_format_of :password, with: /\d/, if: -> { password_requires_digit }, message: :must_contain_digit
 
           # Run as special character check as a custom validation to ensure password_special_characters is evaluated at runtime
           validate :password_must_contain_special_character, if: -> { password_requires_special_character }
@@ -76,24 +76,28 @@ module Devise
 
       # Make these instance methods so the default Devise.password_requires_<> 
       #can be overridden
+      def password_complexity
+        self.class.password_complexity
+      end
+
       def password_requires_lowercase
-        self.class.password_requires_lowercase
+        password_complexity[:require_lower]
       end
 
       def password_requires_uppercase
-        self.class.password_requires_uppercase
+        password_complexity[:require_upper]
       end
       
-      def password_requires_number
-        self.class.password_requires_number 
+      def password_requires_digit
+        password_complexity[:require_digit]
       end
       
       def password_requires_special_character
-        self.class.password_requires_special_character
+        password_complexity[:require_special]
       end
 
       def password_special_characters
-        self.class.password_special_characters
+        password_complexity[:special_characters]
       end
 
       def password_must_contain_special_character
@@ -109,11 +113,7 @@ module Devise
           self,
           :email_regexp,
           :password_length,
-          :password_requires_lowercase,
-          :password_requires_uppercase,
-          :password_requires_special_character,
-          :password_requires_number,
-          :password_special_characters
+          :password_complexity
         )
       end
     end

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -13,11 +13,12 @@ module Devise
     #
     #   * +email_regexp+: the regular expression used to validate e-mails;
     #   * +password_length+: a range expressing password length. Defaults to 6..128.
-    #   * +password_requires_lowercase+: a boolean to require a lower case letter in the password. Defaults to false.
-    #   * +password_requires_uppercase+: a boolean to require an upper case letter in the password. Defaults to false.
-    #   * +password_requires_special_character+: a boolean to require a special character in the password. Defaults to false.
-    #   * +password_requires_digit+: a boolean to require a digit in the password. Defaults to false.
-    #   * +password_special_characters+: a string with the special characters that are allowed in the password. Defaults to nil.
+    #   * +password_complexity+: a hash with the password complexity requirements, with the following keys:
+    #       - +require_lower+: a boolean to require a lower case letter in the password. Defaults to false.
+    #       - +require_upper+: a boolean to require an upper case letter in the password. Defaults to false.
+    #       - +require_special+: a boolean to require a special character in the password. Defaults to false.
+    #       - +require_digit+: a boolean to require a digit in the password. Defaults to false.
+    #       - +special_characters+: a string with the special characters that are allowed in the password. Defaults to nil.
     #
     # Since +password_length+ is applied in a proc within `validates_length_of` it can be overridden
     # at runtime.

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -185,20 +185,14 @@ Devise.setup do |config|
   # to give user feedback and not to assert the e-mail validity.
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
-  # Password requires a lower case letter
-  # config.password_requires_lowercase = false
-
-  # Password requires an upper case letter
-  # config.password_requires_uppercase = false
-
-  # Password requires a number
-  # config.password_requires_number = false
-
-  # Password requires a special character
-  # config.password_requires_special_character = false
-
-  # Special characters that are allowed in the password
-  # config.password_special_characters = "!?@#$%^&*()_+-=[]{}|:;<>,./"
+  # Password complexity configuration
+  # config.password_complexity = {
+  #   require_upper: false,    
+  #   require_lower: false,    
+  #   require_digit: false,   
+  #   require_special: false,  
+  #   special_characters: "!?@#$%^&*()_+-=[]{}|:;<>,./"
+  # }
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/lib/generators/templates/devise.rb
+++ b/lib/generators/templates/devise.rb
@@ -185,6 +185,21 @@ Devise.setup do |config|
   # to give user feedback and not to assert the e-mail validity.
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
+  # Password requires a lower case letter
+  # config.password_requires_lowercase = false
+
+  # Password requires an upper case letter
+  # config.password_requires_uppercase = false
+
+  # Password requires a number
+  # config.password_requires_number = false
+
+  # Password requires a special character
+  # config.password_requires_special_character = false
+
+  # Special characters that are allowed in the password
+  # config.password_special_characters = "!?@#$%^&*()_+-=[]{}|:;<>,./"
+
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -1,9 +1,9 @@
 # encoding: UTF-8
 # frozen_string_literal: true
-require "test_helper"
+require 'test_helper'
 
 class ValidatableTest < ActiveSupport::TestCase
-  test 'should require email to be set' do      
+  test 'should require email to be set' do
     user = new_user(email: nil)
     assert user.invalid?
     assert user.errors[:email]
@@ -176,7 +176,7 @@ class ValidatableTest < ActiveSupport::TestCase
 
 
   test "special character must be within defined special character set if it is custom" do
-  with_password_requirement(:require_special, true) do
+    with_password_requirement(:require_special, true) do
       with_password_requirement(:special_characters, '!') do
         user = new_user(password: 'password!', password_confirmation: 'password!')
         assert user.valid?  
@@ -191,7 +191,6 @@ class ValidatableTest < ActiveSupport::TestCase
   def with_password_requirement(requirement, value)
     # Change the password requirement and restore it after the block is executed
     original_password_complexity= User.public_send("password_complexity")
-    original_value = original_password_complexity[requirement]
 
     updated_password_complexity = original_password_complexity.dup
     updated_password_complexity[requirement] = value

--- a/test/models/validatable_test.rb
+++ b/test/models/validatable_test.rb
@@ -122,52 +122,52 @@ class ValidatableTest < ActiveSupport::TestCase
   end
 
   
-  test "password must require a lower case letter if password_requires_lowercase_letter is true" do
-    with_password_requirement(:password_requires_lowercase, false) do
+  test "password must require a lower case letter if require_lower is true" do
+    with_password_requirement(:require_lower, false) do
       user = new_user(password: 'PASSWORD', password_confirmation: 'PASSWORD')
       assert user.valid?  
     end
     
-    with_password_requirement(:password_requires_lowercase, true) do
+    with_password_requirement(:require_lower, true) do
       user = new_user(password: 'PASSWORD', password_confirmation: 'PASSWORD')
       assert user.invalid?
       assert_equal 'must include at least one lowercase letter', user.errors[:password].join
     end
   end  
 
-  test "password must require an upper case letter if password_requires_uppercase_letter is true" do
-    with_password_requirement(:password_requires_uppercase, false) do
+  test "password must require an upper case letter if require_upper is true" do
+    with_password_requirement(:require_upper, false) do
       user = new_user(password: 'password', password_confirmation: 'password')
       assert user.valid?  
     end
     
-    with_password_requirement(:password_requires_uppercase, true) do
+    with_password_requirement(:require_upper, true) do
       user = new_user(password: 'password', password_confirmation: 'password')
       assert user.invalid?
       assert_equal 'must include at least one uppercase letter', user.errors[:password].join
     end
   end  
 
-  test "password must require an upper case letter if password_requires_number is true" do
-    with_password_requirement(:password_requires_number, false) do
+  test "password must require an upper case letter if require_digit is true" do
+    with_password_requirement(:require_digit, false) do
       user = new_user(password: 'password', password_confirmation: 'password')
       assert user.valid?  
     end
     
-    with_password_requirement(:password_requires_number, true) do
+    with_password_requirement(:require_digit, true) do
       user = new_user(password: 'password', password_confirmation: 'password')
       assert user.invalid?
       assert_equal 'must include at least one number', user.errors[:password].join
     end
   end 
 
-  test "password must require special character if password_requires_special_character is true" do
-    with_password_requirement(:password_requires_special_character, false) do
+  test "password must require special character if require_special is true" do
+    with_password_requirement(:require_special, false) do
       user = new_user(password: 'password', password_confirmation: 'password')
       assert user.valid?  
     end
     
-    with_password_requirement(:password_requires_special_character, true) do
+    with_password_requirement(:require_special, true) do
       user = new_user(password: 'password', password_confirmation: 'password')
       assert user.invalid?
       assert_equal 'must include at least one special character', user.errors[:password].join
@@ -176,8 +176,8 @@ class ValidatableTest < ActiveSupport::TestCase
 
 
   test "special character must be within defined special character set if it is custom" do
-    with_password_requirement(:password_requires_special_character, true) do
-      with_password_requirement(:password_special_characters, '!') do
+  with_password_requirement(:require_special, true) do
+      with_password_requirement(:special_characters, '!') do
         user = new_user(password: 'password!', password_confirmation: 'password!')
         assert user.valid?  
 
@@ -190,10 +190,15 @@ class ValidatableTest < ActiveSupport::TestCase
 
   def with_password_requirement(requirement, value)
     # Change the password requirement and restore it after the block is executed
-    original_value = User.public_send(requirement)
-    User.public_send("#{requirement}=", value)
+    original_password_complexity= User.public_send("password_complexity")
+    original_value = original_password_complexity[requirement]
+
+    updated_password_complexity = original_password_complexity.dup
+    updated_password_complexity[requirement] = value
+
+    User.public_send("password_complexity=", updated_password_complexity)
     yield
   ensure
-    User.public_send("#{requirement}=", original_value)
+    User.public_send("password_complexity=", original_password_complexity)
   end
 end

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -100,21 +100,15 @@ Devise.setup do |config|
 
   # Regex to use to validate the email address
   # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
-
-  # Password requires a lower case letter
-  # config.password_requires_lowercase = false
-
-  # Password requires an upper case letter
-  # config.password_requires_uppercase = false
-
-  # Password requires a number
-  # config.password_requires_number = false
-
-  # Password requires a special character
-  # config.password_requires_special_character = false
-
-  # Special characters that are allowed in the password
-  # config.password_special_characters = "!?@#$%^&*()_+-=[]{}|:;<>,./"
+  
+  # Password complexity configuration
+  # config.password_complexity = {
+  #   require_upper: false,    
+  #   require_lower: false,    
+  #   require_digit: false,   
+  #   require_special: false,  
+  #   special_characters: "!?@#$%^&*()_+-=[]{}|:;<>,./"
+  # }
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/test/rails_app/config/initializers/devise.rb
+++ b/test/rails_app/config/initializers/devise.rb
@@ -101,6 +101,21 @@ Devise.setup do |config|
   # Regex to use to validate the email address
   # config.email_regexp = /^([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})$/i
 
+  # Password requires a lower case letter
+  # config.password_requires_lowercase = false
+
+  # Password requires an upper case letter
+  # config.password_requires_uppercase = false
+
+  # Password requires a number
+  # config.password_requires_number = false
+
+  # Password requires a special character
+  # config.password_requires_special_character = false
+
+  # Special characters that are allowed in the password
+  # config.password_special_characters = "!?@#$%^&*()_+-=[]{}|:;<>,./"
+
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.


### PR DESCRIPTION
In relation to https://github.com/heartcombo/devise/issues/5591

This PR introduces application config to allow for password complexity to granularly managed with new validation options for:
* presence of a lower case letter
* presence of a upper case letter
* presence of a number
* presence of a special character (from a list of special characters that is configurable)

These are all `false` by default, and configurable like:
```ruby
Devise.setup do |config|
      config.password_length = 8..128 # (existing)
      config.password_requires_lowercase = true
      config.password_requires_uppercase = true
      config.password_requires_number = true
      config.password_requires_special_character = true
      config.password_special_characters = ":)"
end
```

**Note** 
* I haven't run any linting, I couldn't find instructions on what config was used for that 😄 
* I haven't updated any docs, please advise where I need to update if at all 🙏 

