### PR TITLE
Make Devise.mappings work with lazy loaded routes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,18 @@
   * Remove `SecretKeyFinder` and use `app.secret_key_base` as the default secret key for `Devise.secret_key` if a custom `Devise.secret_key` is not provided.
 
     This is potentially a breaking change because Devise previously used the following order to find a secret key:
-    
+
     ```
     app.credentials.secret_key_base > app.secrets.secret_key_base > application.config.secret_key_base > application.secret_key_base
     ```
-    
+
     Now, it always uses `application.secret_key_base`. Make sure you're using the same secret key after the upgrade; otherwise, previously generated tokens for `recoverable`, `lockable`, and `confirmable` will be invalid.
     https://github.com/heartcombo/devise/pull/5645
 
 * enhancements
   * Removed deprecations warning output for `Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION` (@soartec-lab)
+  * Add Rails 8 support.
+    - Routes are lazy-loaded by default in test and development environments now so Devise loads them before `Devise.mappings` call.
 
 Please check [4-stable](https://github.com/heartcombo/devise/blob/4-stable/CHANGELOG.md)
 for previous changes.

--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -274,8 +274,14 @@ module Devise
   # PRIVATE CONFIGURATION
 
   # Store scopes mappings.
-  mattr_reader :mappings
   @@mappings = {}
+  def self.mappings
+    # Starting from Rails 8.0, routes are lazy-loaded by default in test and development environments.
+    # However, Devise's mappings are built during the routes loading phase.
+    # To ensure it works correctly, we need to load the routes first before accessing @@mappings.
+    Rails.application.try(:reload_routes_unless_loaded)
+    @@mappings
+  end
 
   # OmniAuth configurations.
   mattr_reader :omniauth_configs


### PR DESCRIPTION
Starting from Rails 8.0, routes are lazy-loaded by default in test and development environments. However, Devise's mappings are built during the routes loading phase. To ensure it works correctly, we need to load the routes first before accessing `@@mappings`.

Closes https://github.com/heartcombo/devise/issues/5705 https://github.com/heartcombo/devise/pull/5695