### PR TITLE
Fix Rails main CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
             ruby: '2.7' # Rails > 7.1 supports Ruby >= 3.1
           - gemfile: gemfiles/Gemfile-rails-main
             ruby: '3.0' # Rails > 7.1 supports Ruby >= 3.1
+          - gemfile: gemfiles/Gemfile-rails-main
+            ruby: '3.1' # Rails >= 8.0 supports Ruby >= 3.2
           - gemfile: Gemfile
             env: DEVISE_ORM=mongoid
           - gemfile: gemfiles/Gemfile-rails-main


### PR DESCRIPTION
CI is currently failing for Gemfile-rails-main because Rails 8+ requires Ruby 3.2+.

This PR tweaks the CI config to ignore Rails 3.1 for Rails main.
