### PR TITLE
Fix Zeitwerk autoloading when ActionMailer is not present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,5 +19,8 @@
   * Add Rails 8 support.
     - Routes are lazy-loaded by default in test and development environments now so Devise loads them before `Devise.mappings` call.
 
+* bug fixes
+  * Make `Devise` work without `ActionMailer` when `Zeitwerk` autoloader is used.
+
 Please check [4-stable](https://github.com/heartcombo/devise/blob/4-stable/CHANGELOG.md)
 for previous changes.

--- a/lib/devise/rails.rb
+++ b/lib/devise/rails.rb
@@ -47,5 +47,11 @@ module Devise
           )
         end
     end
+
+    initializer "devise.configure_zeitwerk" do
+      if Rails.autoloaders.zeitwerk_enabled? && !defined?(ActionMailer)
+        Rails.autoloaders.main.ignore("#{root}/app/mailers/devise/mailer.rb")
+      end
+    end
   end
 end


### PR DESCRIPTION
When `ActionMailer` is not defined we have empty `app/mailers/devise/mailer.rb` file and Zeitwerk doesn't like that and errors with

`expected file app/mailers/devise/mailer.rb to define constant Devise::Mailer`

The fix is to tell Zeitwerk to ignore that file if `ActionMailer` constant if not defined. 

I tried to write a spec for it but since specs are run in the same process it's hard to have two Rails applications where one of them has `ActionMailer` define and the seconds one doesn't.

closes #5140, #5485