### PR TITLE
Use proc to set password length validator so it's possible to override it dynamically.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,19 @@
   * Removed deprecations warning output for `Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION` (@soartec-lab)
   * Add Rails 8 support.
     - Routes are lazy-loaded by default in test and development environments now so Devise loads them before `Devise.mappings` call.
+  * Password length validator is changed from
 
+    ```
+    validates_length_of :password, within: password_length, allow_blank: true`
+    ```
+
+    to
+
+    ```
+    validates_length_of :password, minimum: proc { password_length.min }, maximum: proc { password_length.max }, allow_blank: true
+    ```
+
+    so it's possible to override `password_length` at runtime. (@manojmj92)
 * bug fixes
   * Make `Devise` work without `ActionMailer` when `Zeitwerk` autoloader is used.
 

--- a/lib/devise/models/validatable.rb
+++ b/lib/devise/models/validatable.rb
@@ -14,6 +14,8 @@ module Devise
     #   * +email_regexp+: the regular expression used to validate e-mails;
     #   * +password_length+: a range expressing password length. Defaults to 6..128.
     #
+    # Since +password_length+ is applied in a proc within `validates_length_of` it can be overridden
+    # at runtime.
     module Validatable
       # All validations used by this module.
       VALIDATIONS = [:validates_presence_of, :validates_uniqueness_of, :validates_format_of,
@@ -34,7 +36,7 @@ module Devise
 
           validates_presence_of     :password, if: :password_required?
           validates_confirmation_of :password, if: :password_required?
-          validates_length_of       :password, within: password_length, allow_blank: true
+          validates_length_of       :password, minimum: proc { password_length.min }, maximum: proc { password_length.max }, allow_blank: true
         end
       end
 

--- a/test/models_test.rb
+++ b/test/models_test.rb
@@ -26,8 +26,8 @@ class ActiveRecordTest < ActiveSupport::TestCase
   test 'validations options are not applied too late' do
     validators = WithValidation.validators_on :password
     length = validators.find { |v| v.kind == :length }
-    assert_equal 2, length.options[:minimum]
-    assert_equal 6, length.options[:maximum]
+    assert_equal 2, length.options[:minimum].call
+    assert_equal 6, length.options[:maximum].call
   end
 
   test 'validations are applied just once' do


### PR DESCRIPTION
This change is useful for instances where applications have the need to support dynamic password lengths, without a system restart. Such applications will just have to override the `password_length` method in their own classes to support dynamic password lengths.

Gitlab uses it like this:

```ruby
class User < ApplicationRecord
  ...
  class << self
    # Devise method overridden to allow support for dynamic password lengths
    def password_length
      Gitlab::CurrentSettings.minimum_password_length..Devise.password_length.max
    end
  end
end
```