### PR TITLE
Allow sign_up_params in GET /resource/sign_up

### DIFF
--- a/app/controllers/devise/registrations_controller.rb
+++ b/app/controllers/devise/registrations_controller.rb
@@ -7,7 +7,7 @@ class Devise::RegistrationsController < DeviseController
 
   # GET /resource/sign_up
   def new
-    build_resource
+    build_resource(sign_up_params)
     yield resource if block_given?
     respond_with resource
   end


### PR DESCRIPTION
This would allow to prefill the user's email on the sign-up page via URL params, which is allowed in the SessionController#new.