### PR TITLE
Fix typo in comments

### DIFF
--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -84,7 +84,7 @@ module Devise
         if_access_locked { send_unlock_instructions }
       end
 
-      # Overwrites active_for_authentication? from Devise::Models::Activatable for locking purposes
+      # Overwrites active_for_authentication? from Devise::Models::Authenticatable for locking purposes
       # by verifying whether a user is active to sign in or not based on locked?
       def active_for_authentication?
         super && !access_locked?


### PR DESCRIPTION
Is this typo?
Sorry, I can't English.

1. I set pry to confirm.
```ruby
# lib/devise/models/lockable.rb:90

# Overwrites active_for_authentication? from Devise::Models::Activatable for locking purposes
# by verifying whether a user is active to sign in or not based on locked?
def active_for_authentication?
  binding.pry
  super && !access_locked?
end
```

2. I ran this to confirm.
```bash
bin/test test/models/lockable_test.rb:93
```

3. I ran this to confirm.
```ruby
method(__method__).super_method.source_location
# => [~~~/lib/devise/models/confirmable.rb", 144]

method(__method__).super_method.super_method.source_location
# => [~~~/lib/devise/models/authenticatable.rb", 89]

method(__method__).super_method.super_method.super_method.source_location
# => nil
```