### PR TITLE
Add sanitization to the passwords controller

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -80,4 +80,8 @@ class Devise::PasswordsController < DeviseController
     def translation_scope
       'devise.passwords'
     end
+
+    def resource_params
+      devise_parameter_sanitizer.sanitize(:reset_password)
+    end
 end

--- a/lib/devise/parameter_sanitizer.rb
+++ b/lib/devise/parameter_sanitizer.rb
@@ -38,7 +38,8 @@ module Devise
     DEFAULT_PERMITTED_ATTRIBUTES = {
       sign_in: [:password, :remember_me],
       sign_up: [:password, :password_confirmation],
-      account_update: [:password, :password_confirmation, :current_password]
+      account_update: [:password, :password_confirmation, :current_password],
+      reset_password: [:reset_password_token, :password, :password_confirmation]
     }
 
     def initialize(resource_class, resource_name, params)

--- a/test/parameter_sanitizer_test.rb
+++ b/test/parameter_sanitizer_test.rb
@@ -58,6 +58,13 @@ class ParameterSanitizerTest < ActiveSupport::TestCase
     assert_equal({ 'email' => 'jose' }, sanitized)
   end
 
+  test 'permits the default parameters for password reset' do
+    sanitizer = sanitizer('user' => { 'email' => 'jose', 'password' => 'myPassword1234', 'role' => 'invalid' })
+    sanitized = sanitizer.sanitize(:reset_password)
+
+    assert_equal({ 'email' => 'jose', 'password' => 'myPassword1234' }, sanitized)
+  end
+
   test 'permits news parameters for an existing action' do
     sanitizer = sanitizer('user' => { 'username' => 'jose' })
     sanitizer.permit(:sign_in, keys: [:username])


### PR DESCRIPTION
Closes https://github.com/heartcombo/devise/issues/5747.

## What
Introduces the `:reset_password` parameter.
 
 ## Why
Sanitizes the `resource_params` used in the `:PasswordsController` to conform with the `Registration & SessionControllers`.
