### PR TITLE
Translate error messages in the activatable and timeoutable hooks

### DIFF
--- a/lib/devise/hooks/activatable.rb
+++ b/lib/devise/hooks/activatable.rb
@@ -7,6 +7,6 @@ Warden::Manager.after_set_user do |record, warden, options|
   if record && record.respond_to?(:active_for_authentication?) && !record.active_for_authentication?
     scope = options[:scope]
     warden.logout(scope)
-    throw :warden, scope: scope, message: record.inactive_message
+    throw :warden, scope: scope, message: record.inactive_message, locale: options[:locale]
   end
 end

--- a/lib/devise/hooks/timeoutable.rb
+++ b/lib/devise/hooks/timeoutable.rb
@@ -25,7 +25,7 @@ Warden::Manager.after_set_user do |record, warden, options|
         record.timedout?(last_request_at) &&
         !proxy.remember_me_is_active?(record)
       Devise.sign_out_all_scopes ? proxy.sign_out : proxy.sign_out(scope)
-      throw :warden, scope: scope, message: :timeout
+      throw :warden, scope: scope, message: :timeout, locale: options[:locale]
     end
 
     unless env['devise.skip_trackable']

--- a/test/helpers/devise_helper_test.rb
+++ b/test/helpers/devise_helper_test.rb
@@ -14,7 +14,7 @@ class DeviseHelperTest < Devise::IntegrationTest
       mongoid: model_labels
     }
 
-    I18n.available_locales
+    I18n.backend.eager_load!
     I18n.backend.store_translations(:en, translations)
   end
 

--- a/test/integration/activatable_test.rb
+++ b/test/integration/activatable_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ActivatableTest < Devise::IntegrationTest
+  test 'shows the localized error message for inactive accounts' do
+    store_translations(
+      en: { devise: { failure: { unconfirmed: 'Unconfirmed account.' } } },
+      de: { devise: { failure: { unconfirmed: 'Unbestätigtes Konto!' } } }
+    ) do
+      I18n.with_locale(:de) do
+        user = create_user(confirm: false, confirmation_sent_at: 1.hour.ago)
+        get new_user_session_path
+        fill_in 'email', with: user.email
+        fill_in 'password', with: user.password
+        click_button 'Log In'
+
+        assert_contain('Unbestätigtes Konto!')
+      end
+    end
+  end
+end

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -334,7 +334,9 @@ class AuthenticationRedirectTest < Devise::IntegrationTest
   end
 
   test 'require_no_authentication should set the already_authenticated flash message as admin' do
-    store_translations :en, devise: { failure: { admin: { already_authenticated: 'You are already signed in as admin.' } } } do
+    store_translations en: {
+      devise: { failure: { admin: { already_authenticated: 'You are already signed in as admin.' } } }
+    } do
       sign_in_as_admin
       visit new_admin_session_path
       assert_equal "You are already signed in as admin.", flash[:alert]

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -206,8 +206,8 @@ class ConfirmationTest < Devise::IntegrationTest
   end
 
   test 'error message is configurable by resource name' do
-    store_translations :en, devise: {
-      failure: { user: { unconfirmed: "Not confirmed user" } }
+    store_translations en: {
+      devise: { failure: { user: { unconfirmed: "Not confirmed user" } } }
     } do
       sign_in_as_user(confirm: false)
       assert_contain 'Not confirmed user'

--- a/test/integration/database_authenticatable_test.rb
+++ b/test/integration/database_authenticatable_test.rb
@@ -55,7 +55,9 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
   end
 
   test 'sign in with invalid email should return to sign in form with error message' do
-    store_translations :en, devise: { failure: { admin: { not_found_in_database: 'Invalid email address' } } } do
+    store_translations en: {
+      devise: { failure: { admin: { not_found_in_database: 'Invalid email address' } } }
+    } do
       sign_in_as_admin do
         fill_in 'email', with: 'wrongemail@test.com'
       end
@@ -76,7 +78,9 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
 
   test 'when in paranoid mode and without a valid e-mail' do
     swap Devise, paranoid: true do
-      store_translations :en, devise: { failure: { not_found_in_database: 'Not found in database' } } do
+      store_translations en: {
+        devise: { failure: { not_found_in_database: 'Not found in database' } }
+      } do
         sign_in_as_user do
           fill_in 'email', with: 'wrongemail@test.com'
         end
@@ -88,7 +92,9 @@ class DatabaseAuthenticationTest < Devise::IntegrationTest
   end
 
   test 'error message is configurable by resource name' do
-    store_translations :en, devise: { failure: { admin: { invalid: "Invalid credentials" } } } do
+    store_translations en: {
+      devise: { failure: { admin: { invalid: "Invalid credentials" } } }
+    } do
       sign_in_as_admin do
         fill_in 'password', with: 'abcdef'
       end

--- a/test/integration/lockable_test.rb
+++ b/test/integration/lockable_test.rb
@@ -103,10 +103,7 @@ class LockTest < Devise::IntegrationTest
   end
 
   test 'error message is configurable by resource name' do
-    store_translations :en, devise: {
-        failure: {user: {locked: "You are locked!"}}
-    } do
-
+    store_translations en: { devise: { failure: { user: { locked: "You are locked!"} } } } do
       user = create_user(locked: true)
       user.failed_attempts = User.maximum_attempts + 1
       user.save!
@@ -117,10 +114,7 @@ class LockTest < Devise::IntegrationTest
   end
 
   test "user should not be able to sign in when locked" do
-    store_translations :en, devise: {
-        failure: {user: {locked: "You are locked!"}}
-    } do
-
+    store_translations en: { devise: { failure: { user: { locked: "You are locked!"} } } } do
       user = create_user(locked: true)
       user.failed_attempts = User.maximum_attempts + 1
       user.save!

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -141,9 +141,7 @@ class SessionTimeoutTest < Devise::IntegrationTest
   end
 
   test 'error message with i18n' do
-    store_translations :en, devise: {
-      failure: { user: { timeout: 'Session expired!' } }
-    } do
+    store_translations en: { devise: { failure: { user: { timeout: 'Session expired!' } } } } do
       user = sign_in_as_user
 
       get expire_user_path(user)
@@ -154,9 +152,7 @@ class SessionTimeoutTest < Devise::IntegrationTest
   end
 
   test 'error message with i18n with double redirect' do
-    store_translations :en, devise: {
-      failure: { user: { timeout: 'Session expired!' } }
-    } do
+    store_translations en: { devise: { failure: { user: { timeout: 'Session expired!' } } } } do
       user = sign_in_as_user
 
       get expire_user_path(user)

--- a/test/integration/timeoutable_test.rb
+++ b/test/integration/timeoutable_test.rb
@@ -163,6 +163,24 @@ class SessionTimeoutTest < Devise::IntegrationTest
     end
   end
 
+  test 'shows the localized error message on session timeout' do
+    # Set up the error message in the default and in a different locale
+    store_translations(
+      en: { devise: { failure: { user: { timeout: 'Session expired!' } } } },
+      de: { devise: { failure: { timeout: 'Sitzung abgelaufen!' } } }
+    ) do
+      I18n.with_locale(:de) do
+        user = sign_in_as_user
+
+        get expire_user_path(user)
+        get users_path
+        follow_redirect!
+        follow_redirect!
+        assert_contain('Sitzung abgelaufen!')
+      end
+    end
+  end
+
   test 'time out not triggered if remembered' do
     user = sign_in_as_user remember_me: true
     get expire_user_path(user)

--- a/test/mailers/confirmation_instructions_test.rb
+++ b/test/mailers/confirmation_instructions_test.rb
@@ -69,13 +69,17 @@ class ConfirmationInstructionsTest < ActionMailer::TestCase
   end
 
   test 'set up subject from I18n' do
-    store_translations :en, devise: { mailer: { confirmation_instructions: { subject: 'Account Confirmation' } } } do
+    store_translations en: {
+      devise: { mailer: { confirmation_instructions: { subject: 'Account Confirmation' } } }
+    } do
       assert_equal 'Account Confirmation', mail.subject
     end
   end
 
   test 'subject namespaced by model' do
-    store_translations :en, devise: { mailer: { confirmation_instructions: { user_subject: 'User Account Confirmation' } } } do
+    store_translations en: {
+      devise: { mailer: { confirmation_instructions: { user_subject: 'User Account Confirmation' } } }
+    } do
       assert_equal 'User Account Confirmation', mail.subject
     end
   end

--- a/test/mailers/email_changed_test.rb
+++ b/test/mailers/email_changed_test.rb
@@ -73,13 +73,17 @@ class EmailChangedTest < ActionMailer::TestCase
   end
 
   test 'set up subject from I18n' do
-    store_translations :en, devise: { mailer: { email_changed: { subject: 'Email Has Changed' } } } do
+    store_translations en: {
+      devise: { mailer: { email_changed: { subject: 'Email Has Changed' } } }
+    } do
       assert_equal 'Email Has Changed', mail.subject
     end
   end
 
   test 'subject namespaced by model' do
-    store_translations :en, devise: { mailer: { email_changed: { user_subject: 'User Email Has Changed' } } } do
+    store_translations en: {
+      devise: { mailer: { email_changed: { user_subject: 'User Email Has Changed' } } }
+    } do
       assert_equal 'User Email Has Changed', mail.subject
     end
   end

--- a/test/mailers/reset_password_instructions_test.rb
+++ b/test/mailers/reset_password_instructions_test.rb
@@ -65,13 +65,17 @@ class ResetPasswordInstructionsTest < ActionMailer::TestCase
   end
 
   test 'set up subject from I18n' do
-    store_translations :en, devise: { mailer: { reset_password_instructions: { subject: 'Reset instructions' } } } do
+    store_translations en: {
+      devise: { mailer: { reset_password_instructions: { subject: 'Reset instructions' } } }
+    } do
       assert_equal 'Reset instructions', mail.subject
     end
   end
 
   test 'subject namespaced by model' do
-    store_translations :en, devise: { mailer: { reset_password_instructions: { user_subject: 'User Reset Instructions' } } } do
+    store_translations en: {
+      devise: { mailer: { reset_password_instructions: { user_subject: 'User Reset Instructions' } } }
+    } do
       assert_equal 'User Reset Instructions', mail.subject
     end
   end

--- a/test/mailers/unlock_instructions_test.rb
+++ b/test/mailers/unlock_instructions_test.rb
@@ -66,13 +66,17 @@ class UnlockInstructionsTest < ActionMailer::TestCase
   end
 
   test 'set up subject from I18n' do
-    store_translations :en, devise: { mailer: { unlock_instructions:  { subject: 'Yo unlock instructions' } } } do
+    store_translations en: {
+      devise: { mailer: { unlock_instructions:  { subject: 'Yo unlock instructions' } } }
+    } do
       assert_equal 'Yo unlock instructions', mail.subject
     end
   end
 
   test 'subject namespaced by model' do
-    store_translations :en, devise: { mailer: { unlock_instructions: { user_subject: 'User Unlock Instructions' } } } do
+    store_translations en: {
+      devise: { mailer: { unlock_instructions: { user_subject: 'User Unlock Instructions' } } }
+    } do
       assert_equal 'User Unlock Instructions', mail.subject
     end
   end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -8,11 +8,10 @@ class ActiveSupport::TestCase
   end
 
   def store_translations(locale, translations, &block)
-    # Calling 'available_locales' before storing the translations to ensure
-    # that the I18n backend will be initialized before we store our custom
-    # translations, so they will always override the translations for the
-    # YML file.
-    I18n.available_locales
+    # Eager-loading the backend before storing the translations ensures that the I18n backend will
+    # always be initialized before we store our custom translations, so the test-specific
+    # translations override the translations from the YML file.
+    I18n.backend.eager_load!
     I18n.backend.store_translations(locale, translations)
     yield
   ensure

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -10,20 +10,12 @@ class ActiveSupport::TestCase
   def store_translations(translations)
     # Eager-loading the backend before storing the translations ensures that the I18n backend will
     # always be initialized before we store our custom translations, so the test-specific
-    # translations override the translations from the YML files. Locking on a mutex guarantees that
-    # concurrent tests calling the same method don't interfere with each other. Note that I18n has a
-    # global state so all interactions with it outside of store_translations may cause unexpected
-    # runtime errors.
-    self.class.i18n_mutex.lock
+    # translations override the translations from the YML files.
     I18n.backend.eager_load!
-    original_locales = I18n.available_locales
-    I18n.available_locales = Set.new(original_locales + translations.keys).to_a
     translations.each { |locale, entries| I18n.backend.store_translations(locale, entries) }
     yield
   ensure
-    I18n.available_locales = original_locales
     I18n.reload!
-    self.class.i18n_mutex.unlock
   end
 
   def generate_unique_email
@@ -95,9 +87,5 @@ class ActiveSupport::TestCase
         mapping.to.instance_variable_set(:@devise_parameter_filter, nil)
       end
     end
-  end
-
-  def self.i18n_mutex
-    @i18n_mutex ||= Mutex.new
   end
 end

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -7,12 +7,12 @@ class ActiveSupport::TestCase
     ActionMailer::Base.deliveries = []
   end
 
-  def store_translations(locale, translations, &block)
+  def store_translations(translations)
     # Eager-loading the backend before storing the translations ensures that the I18n backend will
     # always be initialized before we store our custom translations, so the test-specific
     # translations override the translations from the YML file.
     I18n.backend.eager_load!
-    I18n.backend.store_translations(locale, translations)
+    translations.each { |locale, entries| I18n.backend.store_translations(locale, entries) }
     yield
   ensure
     I18n.reload!

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -12,9 +12,12 @@ class ActiveSupport::TestCase
     # always be initialized before we store our custom translations, so the test-specific
     # translations override the translations from the YML file.
     I18n.backend.eager_load!
+    original_locales = I18n.available_locales
+    I18n.available_locales = Set.new(original_locales + translations.keys).to_a
     translations.each { |locale, entries| I18n.backend.store_translations(locale, entries) }
     yield
   ensure
+    I18n.available_locales = original_locales
     I18n.reload!
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,8 @@ require "rails/test_help"
 require "orm/#{DEVISE_ORM}"
 
 I18n.load_path.concat Dir["#{File.dirname(__FILE__)}/support/locale/*.yml"]
+# Allow setting test-specific locales even if they are not defined in the locale YAML files.
+I18n.enforce_available_locales = false
 
 require 'mocha/minitest'
 require 'timecop'


### PR DESCRIPTION
Pass down the current locale to the Warden error handler in the _activatable_ and _timeoutable_ hooks.

When used from a Rails application and a [timeout](https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/lib/devise/hooks/timeoutable.rb#L28) occurs or when a user tries to sign in with an [unconfirmed account](https://github.com/heartcombo/devise/blob/fec67f98f26fcd9a79072e4581b1bd40d0c7fa1d/lib/devise/hooks/activatable.rb#L10), Devise hands off the error handling to Warden by throwing an exception. Before Warden takes over, the current locale is lost and the error messages are displayed with the default locale. This was addressed in https://github.com/heartcombo/devise/pull/5567, but he _activatable_ and _timeoutable_ hooks were not in the scope of that PR.

This change closes that gap and ensures that the messages are displayed with the set locale in the aforementioned hooks.

Note that the newly added test cases would pass even without this change, but neither the _activatable_ nor the _timeoutable_ hooks work as expected when Devise is used in the context of a standard Rails app with a specific locale - their error messages would always fall back to the default locale. Passing in the current locale to the `throw` method, however, fixes this issue in Rails, so this PR just adds the necessary change to the code base.

##### Other notable changes in this PR:

- Allow the setting of multiple locales with `store_translations` by replacing the `(locale, translations)` argument-pair with a hash.
- Allow the setting of any locale with the `store_translations` test helper in addition to those that are hardcoded in the locale YAML files by disabling the enforcement of available locales in tests. This way temporary translations in any language can be added dynamically without having to add some dummy translation to the YAML files first.
- Use `I18n.backend.eager_load!` instead of `I18n.available_locales`. The latter is a non-intuitive way to initialize the backend and it also _relies on  the **cached** available locales_. When `I18n.reload!` is called to reset the translations, it leaves the backend in uninitialized state but it doesn't clear the cache, meaning that when `I18n.available_locales` is called after, the backend **may not** be initialized. While the backend may have the necessary translations at this point, this _may_ lead to surprising runtime behavior during translations lookup when the tests interact with `I18n`.

Fixes https://github.com/heartcombo/devise/issues/5765.