### PR TITLE
Reconfigure warden when the middleware stack is rebuilt:

### DIFF
--- a/lib/devise.rb
+++ b/lib/devise.rb
@@ -293,9 +293,13 @@ module Devise
   @@helpers << Devise::Controllers::Helpers
 
   # Private methods to interface with Warden.
-  mattr_accessor :warden_config
+  mattr_reader :warden_config
   @@warden_config = nil
   @@warden_config_blocks = []
+  def self.warden_config=(config)
+    @@warden_configured = nil
+    @@warden_config = config
+  end
 
   # When true, enter in paranoid mode to avoid user enumeration.
   mattr_accessor :paranoid

--- a/test/integration/authenticatable_test.rb
+++ b/test/integration/authenticatable_test.rb
@@ -457,6 +457,23 @@ class AuthenticationOthersTest < Devise::IntegrationTest
     end
   end
 
+  test 'reconfigure warden when the middleware stack is rebuilt' do
+    get "/unauthenticated"
+    assert_equal 401, response.status
+
+    with_routing do |set|
+      set.draw do
+        get "/unauthenticated", to: "streaming#index"
+      end
+
+      refute_nil(Devise.warden_config.failure_app)
+
+      assert_nothing_raised do
+        get "/unauthenticated"
+      end
+    end
+  end
+
   test 'does not intercept Rails 401 responses' do
     get '/unauthenticated'
     assert_equal 401, response.status


### PR DESCRIPTION
Reconfigure warden when the middleware stack is rebuilt:

- ### Problem

  Starting from Rails 7.2, in tests environment, it is possible that Rails will rebuild the middleware stack, which for consequence will create a new Warden middleware that will not be configured by Devise.

  ### Context

  Since this commit https://github.com/rails/rails/commit/79fd5b45a27 upstream, when an application uses the `with_routing` helper to create a temporary route set and defines a route that maps to a controller requiring authentication, an error will be raised on request: "RuntimeError: No Failure App provided"

  The issue is due to a memoization on devise.

  ### Solution

  When the `Devise.warden_config` object is modified, reset the memoization.