### PR TITLE
Raise on invalid scope

### DIFF
--- a/lib/devise/mapping.rb
+++ b/lib/devise/mapping.rb
@@ -36,7 +36,8 @@ module Devise
       obj = obj.devise_scope if obj.respond_to?(:devise_scope)
       case obj
       when String, Symbol
-        return obj.to_sym
+        obj = obj.to_sym
+        return obj if Devise.mappings.key?(obj)
       when Class
         Devise.mappings.each_value { |m| return m.name if obj <= m.to }
       else

--- a/test/mapping_test.rb
+++ b/test/mapping_test.rb
@@ -75,13 +75,19 @@ class MappingTest < ActiveSupport::TestCase
 
   test 'find scope uses devise_scope' do
     user = User.new
-    def user.devise_scope; :special_scope; end
-    assert_equal :special_scope, Devise::Mapping.find_scope!(user)
+    def user.devise_scope; :subdomain_user; end
+    assert_equal :subdomain_user, Devise::Mapping.find_scope!(user)
   end
 
   test 'find scope raises an error if cannot be found' do
     assert_raise RuntimeError do
       Devise::Mapping.find_scope!(String)
+    end
+    assert_raise RuntimeError do
+      Devise::Mapping.find_scope!(:invalid_scope)
+    end
+    assert_raise RuntimeError do
+      Devise::Mapping.find_scope!('invalid_scope')
     end
   end
 


### PR DESCRIPTION
Is there any valid reason for accepting non-existing scopes for `Devise::Mapping.find_scope!`, `Devise::Controllers::SignInOut.sign_out` etc.?

I suggest raising when passing a string/symbol representing a non-existing scope.