### PR TITLE
Do not set unlock_token attribute to undigested value after unlocking user with token

### DIFF
--- a/lib/devise/models/lockable.rb
+++ b/lib/devise/models/lockable.rb
@@ -187,12 +187,10 @@ module Devise
         # If the user is not locked, creates an error for the user
         # Options must have the unlock_token
         def unlock_access_by_token(unlock_token)
-          original_token = unlock_token
-          unlock_token   = Devise.token_generator.digest(self, :unlock_token, unlock_token)
+          unlock_token = Devise.token_generator.digest(self, :unlock_token, unlock_token)
 
           lockable = find_or_initialize_with_error_by(:unlock_token, unlock_token)
           lockable.unlock_access! if lockable.persisted?
-          lockable.unlock_token = original_token
           lockable
         end
 

--- a/test/models/lockable_test.rb
+++ b/test/models/lockable_test.rb
@@ -201,7 +201,9 @@ class LockableTest < ActiveSupport::TestCase
     raw  = user.send_unlock_instructions
     locked_user = User.unlock_access_by_token(raw)
     assert_equal user, locked_user
+    assert_not locked_user.changed?
     assert_not user.reload.access_locked?
+    assert_nil user.reload.unlock_token
   end
 
   test 'should return a new record with errors when a invalid token is given' do


### PR DESCRIPTION
When `User.unlock_access_by_token` is used, Devise unlocks access to the user, and sets the `unlock_token` attribute to the original non-digested token, passed as an argument. If we are to set any other attributes on the unlocked user and save the record, the non-digested token is persisted in the database.

This does not seem to pose any security risks (at least I cannot find any), but I also see no benefit in such behaviour.