### PR TITLE
Fix race condition vulnerability, by ensuring the `unconfirmed_email` is always saved

### DIFF
--- a/lib/devise/models/confirmable.rb
+++ b/lib/devise/models/confirmable.rb
@@ -262,6 +262,7 @@ module Devise
         def postpone_email_change_until_confirmation_and_regenerate_confirmation_token
           @reconfirmation_required = true
           self.unconfirmed_email = self.email
+          unconfirmed_email_will_change!
           self.email = self.devise_email_in_database
           self.confirmation_token = nil
           generate_confirmation_token

--- a/test/integration/confirmable_test.rb
+++ b/test/integration/confirmable_test.rb
@@ -345,4 +345,29 @@ class ConfirmationOnChangeTest < Devise::IntegrationTest
     assert_contain(/Email.*already.*taken/)
     assert admin.reload.pending_reconfirmation?
   end
+
+  test 'concurrent "update email" requests should not allow confirmation_token and unconfirmed_email to get out of sync' do
+    attacker_email = "attacker@example.com"
+    victim_email = "victim@example.com"
+
+    attacker = create_admin
+    # update the email address of the attacker, but do not confirm it yet
+    attacker.update(email: attacker_email)
+
+    # a concurrent request also updates the email address to the victim, while this request's model is in memory
+    Admin.where(id: attacker.id).update_all(
+      unconfirmed_email: victim_email,
+      confirmation_token: "different token"
+    )
+
+    # now we update to the same prior unconfirmed email address, and confirm
+    attacker.update(email: attacker_email)
+    attacker_token = attacker.raw_confirmation_token
+    visit_admin_confirmation_with_token(attacker_token)
+
+    attacker.reload
+    assert attacker.confirmed?
+    assert_equal attacker_email, attacker.email
+  end
+
 end


### PR DESCRIPTION
Fixes https://github.com/heartcombo/devise/issues/5783