### PR TITLE
Fix email enumeration vulnerability in password reset

### DIFF
--- a/app/controllers/devise/passwords_controller.rb
+++ b/app/controllers/devise/passwords_controller.rb
@@ -15,11 +15,9 @@ class Devise::PasswordsController < DeviseController
     self.resource = resource_class.send_reset_password_instructions(resource_params)
     yield resource if block_given?
 
-    if successfully_sent?(resource)
-      respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
-    else
-      respond_with(resource)
-    end
+    # Always show success message to prevent email enumeration
+    set_flash_message! :notice, :send_instructions
+    respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
   end
 
   # GET /resource/password/edit?reset_password_token=abcdef

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
       success: "Successfully authenticated from %{kind} account."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
-      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
       updated: "Your password has been changed successfully. You are now signed in."
       updated_not_active: "Your password has been changed successfully."

--- a/lib/devise/models/recoverable.rb
+++ b/lib/devise/models/recoverable.rb
@@ -118,11 +118,19 @@ module Devise
 
         # Attempt to find a user by its email. If a record is found, send new
         # password instructions to it. If user is not found, returns a new user
-        # with an email not found error.
+        # with no errors to prevent email enumeration attacks.
         # Attributes must contain the user's email
         def send_reset_password_instructions(attributes = {})
           recoverable = find_or_initialize_with_errors(reset_password_keys, attributes, :not_found)
-          recoverable.send_reset_password_instructions if recoverable.persisted?
+          
+          if recoverable.persisted?
+            recoverable.send_reset_password_instructions
+          else
+            # Always return a new user with no errors to prevent email enumeration
+            recoverable = new
+            recoverable.errors.clear
+          end
+          
           recoverable
         end
 

--- a/test/integration/recoverable_test.rb
+++ b/test/integration/recoverable_test.rb
@@ -52,7 +52,7 @@ class PasswordTest < Devise::IntegrationTest
     end
 
     assert_current_url '/users/sign_in'
-    assert_contain 'You will receive an email with instructions on how to reset your password in a few minutes.'
+    assert_contain 'If your email address exists in our database'
   end
 
   test 'reset password with email should send an email from a custom mailer' do
@@ -68,7 +68,7 @@ class PasswordTest < Devise::IntegrationTest
     assert_match edit_user_password_path(reset_password_token: 'abcdef'), mail.body.encoded
   end
 
-  test 'reset password with email of different case should fail when email is NOT the list of case insensitive keys' do
+  test 'reset password with email of different case should show success message when email is NOT the list of case insensitive keys' do
     swap Devise, case_insensitive_keys: [] do
       create_user(email: 'Foo@Bar.com')
 
@@ -76,10 +76,9 @@ class PasswordTest < Devise::IntegrationTest
         fill_in 'email', with: 'foo@bar.com'
       end
 
-      assert_response :success
-      assert_current_url '/users/password'
-      assert_have_selector "input[type=email][value='foo@bar.com']"
-      assert_contain 'not found'
+      # Now always shows success to prevent email enumeration
+      assert_current_url '/users/sign_in'
+      assert_contain 'If your email address exists in our database'
     end
   end
 
@@ -91,10 +90,10 @@ class PasswordTest < Devise::IntegrationTest
     end
 
     assert_current_url '/users/sign_in'
-    assert_contain 'You will receive an email with instructions on how to reset your password in a few minutes.'
+    assert_contain 'If your email address exists in our database'
   end
 
-  test 'reset password with email with extra whitespace should fail when email is NOT the list of strip whitespace keys' do
+  test 'reset password with email with extra whitespace should show success message when email is NOT the list of strip whitespace keys' do
     swap Devise, strip_whitespace_keys: [] do
       create_user(email: 'foo@bar.com')
 
@@ -102,10 +101,9 @@ class PasswordTest < Devise::IntegrationTest
         fill_in 'email', with: ' foo@bar.com '
       end
 
-      assert_response :success
-      assert_current_url '/users/password'
-      assert_have_selector "input[type=email][value=' foo@bar.com ']"
-      assert_contain 'not found'
+      # Now always shows success to prevent email enumeration
+      assert_current_url '/users/sign_in'
+      assert_contain 'If your email address exists in our database'
     end
   end
 
@@ -124,18 +122,17 @@ class PasswordTest < Devise::IntegrationTest
     request_forgot_password
 
     assert_current_url '/users/sign_in'
-    assert_contain 'You will receive an email with instructions on how to reset your password in a few minutes.'
+    assert_contain 'If your email address exists in our database'
   end
 
-  test 'not authenticated user with invalid email should receive an error message' do
+  test 'not authenticated user with invalid email should still see success message' do
     request_forgot_password do
       fill_in 'email', with: 'invalid.test@test.com'
     end
 
-    assert_response :success
-    assert_current_url '/users/password'
-    assert_have_selector "input[type=email][value='invalid.test@test.com']"
-    assert_contain 'not found'
+    # Now always shows success to prevent email enumeration
+    assert_current_url '/users/sign_in'
+    assert_contain 'If your email address exists in our database'
   end
 
   test 'authenticated user should not be able to visit edit password page' do

--- a/test/models/recoverable_test.rb
+++ b/test/models/recoverable_test.rb
@@ -260,4 +260,28 @@ class RecoverableTest < ActiveSupport::TestCase
     assert_nil User.with_reset_password_token('random-token')
   end
 
+  test 'should not expose email existence by default' do
+    user = User.send_reset_password_instructions(email: 'nonexistent@example.com')
+    assert_not user.persisted?
+    assert user.errors.empty?
+  end
+
+  test 'should send reset instructions only for existing users' do
+    existing_user = create_user
+    
+    # Should send email for existing user
+    assert_email_sent do
+      user = User.send_reset_password_instructions(email: existing_user.email)
+      assert user.persisted?
+      assert user.errors.empty?
+    end
+    
+    # Should not send email for non-existing user
+    assert_email_not_sent do
+      user = User.send_reset_password_instructions(email: 'nonexistent@example.com')
+      assert_not user.persisted?
+      assert user.errors.empty?
+    end
+  end
+
 end


### PR DESCRIPTION
## Summary
- Fixes email enumeration vulnerability in password reset functionality
- Makes secure behavior the default (no longer dependent on paranoid mode)
- Updates locale messages to use consistent, vague language that doesn't reveal email existence

## Problem
Previously, the password reset functionality exposed whether an email existed in the system by returning different error messages for existing vs non-existing accounts. This is a security vulnerability that allows attackers to enumerate valid user emails.

## Solution
This PR changes the default behavior to always return a success response with a vague message, regardless of whether the email exists in the database. The message now reads: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."

## Breaking Change
This is a breaking change as it modifies the default behavior of `send_reset_password_instructions`. Applications that rely on the old behavior (showing explicit errors for non-existent emails) will need to be updated.

## Changes Made
1. Modified `send_reset_password_instructions` in `lib/devise/models/recoverable.rb` to always clear errors for non-existent users
2. Updated `PasswordsController#create` to always show success message
3. Updated locale messages to use consistent vague language
4. Updated tests to reflect the new secure-by-default behavior

## Test Plan
- [x] Unit tests updated and passing for the recoverable model
- [x] Integration tests updated to expect the new behavior
- [ ] Manual testing of password reset flow
- [ ] Verify emails are only sent for existing users
- [ ] Verify UI always shows success message

🤖 Generated with [Claude Code](https://claude.ai/code)